### PR TITLE
Fix chat message layout shift on hover

### DIFF
--- a/apps/agent/src/renderer/pages/Chat.tsx
+++ b/apps/agent/src/renderer/pages/Chat.tsx
@@ -503,18 +503,22 @@ export function Chat() {
 
                   {/* Hover timestamp for grouped messages */}
                   {grouped && (
-                    <span className="hidden group-hover:block text-[10px] text-gray-600 shrink-0 self-center">
+                    <span className="invisible group-hover:visible text-[10px] text-gray-600 shrink-0 self-center">
                       {formatTimestamp(msg.created_at)}
                     </span>
                   )}
 
                   {/* Three-dot menu button on hover */}
                   <button
-                    className="hidden group-hover:flex shrink-0 self-center w-6 h-6 items-center justify-center rounded text-gray-600 hover:text-gray-300 hover:bg-white/5 transition-colors"
+                    type="button"
+                    tabIndex={-1}
+                    aria-label="Open message menu"
+                    className="flex invisible group-hover:visible shrink-0 self-center w-6 h-6 items-center justify-center rounded text-gray-600 hover:text-gray-300 hover:bg-white/5 transition-colors"
                     onClick={(e) => {
                       e.stopPropagation();
                       setContextMenu({ x: e.currentTarget.getBoundingClientRect().left - 140, y: e.currentTarget.getBoundingClientRect().bottom + 4, msg });
                     }}
+                    onMouseLeave={(e) => e.currentTarget.blur()}
                   >
                     ⋯
                   </button>


### PR DESCRIPTION
Hovering over a chat message causes a small layout shift. The row gets slightly taller when grouped, and always slightly skinnier because of the `...` menu button. This is caused by elements getting display none when being hidden.

Fix:
 * Replaced hidden/group-hover:block|flex with invisible/group-hover:visible. visibility: hidden reserves layout space while hiding the element, so nothing shifts on hover
 * Changed the button from hidden to flex invisible so it always participates in flex layout

Supporting changes:
 * tabIndex={-1}: the button is now always in the DOM (just invisible), so without this it would be a tab stop you can't see
 * type="button": prevents accidental form submission (HTML default for <button> is submit)
 * aria-label="Open message menu": the button contains no text, which isn't meaningful to screen readers. Probably pointless since this is for melee stuff, but whatever its best practice
 * onMouseLeave blur: clears focus from the button when the mouse leaves, since it's no longer removed from the DOM on unhover, preventing focus on an invisible button
