### PR TITLE
adds Has Mutual Friends filter to Discover page

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -18,7 +18,10 @@
   "dependencies": {
     "@slippi/slippi-js": "^9.0.0",
     "@supabase/supabase-js": "^2.49.0",
+    "@types/archiver": "^7.0.0",
+    "archiver": "^7.0.1",
     "chokidar": "^4.0.0",
+    "electron-log": "^5.4.3",
     "electron-store": "^8.2.0",
     "electron-updater": "^6.8.3",
     "find-process": "^1.4.7",

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/0xburn/friendlies",
   "main": "dist/main.js",
   "scripts": {
-    "dev": "concurrently -n tsc,vite,electron \"tsc -w --preserveWatchOutput\" \"vite\" \"wait-on http://localhost:5173 && NODE_ENV=development electron .\"",
+    "dev": "concurrently -n tsc,vite,electron \"tsc -w --preserveWatchOutput\" \"vite\" \"wait-on http://localhost:5173 && electron . --dev\"",
     "build": "tsc && vite build && electron-builder --publish never",
     "build:mac": "tsc && vite build && electron-builder --mac --publish never",
     "build:win": "tsc && vite build && electron-builder --win --publish never",

--- a/apps/agent/src/chat.ts
+++ b/apps/agent/src/chat.ts
@@ -3,6 +3,7 @@ import { supabase } from './supabase';
 import { sendToRenderer } from './ipc';
 import { getCurrentUser } from './auth';
 import { getIdentity } from './identity';
+import { chatLog } from './logger';
 
 export interface ChatMessage {
   id: string;
@@ -131,9 +132,11 @@ export async function subscribeChatRoom(room: string): Promise<boolean> {
       });
     });
     console.log('[chat] Subscribed to room:', room);
+    chatLog.info('Subscribed to room:', room);
     return true;
   } catch (e) {
     console.error('[chat] Subscribe failed:', e);
+    chatLog.error('Subscribe failed:', e);
     chatChannel = null;
     currentRoom = null;
     return false;
@@ -195,8 +198,10 @@ export async function joinChatPresence(room: string): Promise<void> {
       displayName: identity.displayName || identity.connectCode,
     });
     console.log('[chat] Presence joined for room:', room);
+    chatLog.info('Presence joined for room:', room);
   } catch (e) {
     console.error('[chat] Presence join failed:', e);
+    chatLog.error('Presence join failed:', e);
   }
 }
 
@@ -265,7 +270,7 @@ export async function getChatHistory(
   if (before) query = query.lt('created_at', before);
 
   const { data, error } = await query;
-  if (error) { console.error('[chat] history error:', error.message); return { messages: [], profiles: {} }; }
+  if (error) { console.error('[chat] history error:', error.message); chatLog.error('history error:', error.message); return { messages: [], profiles: {} }; }
 
   const blocked = await getBlockedCodes();
   const messages = (data ?? [])

--- a/apps/agent/src/config.ts
+++ b/apps/agent/src/config.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getEffectiveLauncherDir } from './launcher-path';
+import { mainLog } from './logger';
 
 export const SLIPPI_LAUNCHER_PROCESS_NAMES = [
   'Slippi Launcher',
@@ -176,6 +177,7 @@ export function getDefaultReplayDir(): string {
         const rootSlpPath = data?.settings?.rootSlpPath;
         if (rootSlpPath && typeof rootSlpPath === 'string' && fs.existsSync(rootSlpPath)) {
           console.log(`[config] Replay dir from Slippi Launcher: ${rootSlpPath}`);
+          mainLog.info(`Replay dir from Slippi Launcher: ${rootSlpPath}`);
           return rootSlpPath;
         }
       }

--- a/apps/agent/src/diagnostics.ts
+++ b/apps/agent/src/diagnostics.ts
@@ -1,0 +1,120 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { BrowserWindow, app, dialog, screen } from 'electron';
+import log from 'electron-log/main';
+import archiver from 'archiver';
+import { getSettings } from './settings';
+import { getIdentity } from './identity';
+import { getCurrentStatus, getPresenceStats, isLookingToPlay, getStatusPreset } from './presence';
+
+export async function exportDiagnostics(): Promise<string | null> {
+  const ts = new Date().toISOString().replace(/[:]/g, '-').replace(/\.\d+Z$/, '');
+  const defaultName = `friendlies-diagnostics-${ts}.tar.gz`;
+  const { filePath, canceled } = await dialog.showSaveDialog({
+    title: 'Export Diagnostic Logs',
+    defaultPath: path.join(app.getPath('desktop'), defaultName),
+    filters: [{ name: 'Gzipped Tar', extensions: ['tar.gz'] }],
+  });
+  if (canceled || !filePath) return null;
+
+  const output = fs.createWriteStream(filePath);
+  const archive = archiver('tar', { gzip: true });
+  archive.pipe(output);
+
+  // --- Logs ---
+  try {
+    const allLogs = log.transports.file.readAllLogs();
+    for (const entry of allLogs) {
+      const name = path.basename(entry.path);
+      archive.append(entry.lines.join('\n'), { name });
+    }
+  } catch (e) {
+    archive.append(`Failed to read logs: ${e}`, { name: 'log-error.txt' });
+  }
+
+  // --- Platform info ---
+  const displays = screen.getAllDisplays().map((d) => ({
+    id: d.id,
+    size: d.size,
+    scaleFactor: d.scaleFactor,
+  }));
+
+  let windowSize: { width: number; height: number } | null = null;
+  try {
+    const [win] = BrowserWindow.getAllWindows();
+    if (win) {
+      const [w, h] = win.getSize();
+      windowSize = { width: w, height: h };
+    }
+  } catch {}
+
+  const platformInfo = {
+    platform: os.platform(),
+    platformPretty: getPrettyOSName(),
+    arch: os.arch(),
+    osRelease: os.release(),
+    appVersion: app.getVersion(),
+    windowSize,
+    electronVersion: process.versions.electron,
+    nodeVersion: process.versions.node,
+    chromeVersion: process.versions.chrome,
+    displays,
+  };
+  archive.append(JSON.stringify(platformInfo, null, 2), { name: 'platform-info.json' });
+
+  // --- App state ---
+  const identity = getIdentity();
+  const appState = {
+    connectCode: identity?.connectCode ?? null,
+    displayName: identity?.displayName ?? null,
+    presenceStatus: getCurrentStatus(),
+    lookingToPlay: isLookingToPlay(),
+    statusPreset: getStatusPreset(),
+    presenceStats: getPresenceStats(),
+    settings: getSettings(),
+  };
+  archive.append(JSON.stringify(appState, null, 2), { name: 'app-state.json' });
+
+  await archive.finalize();
+
+  // Wait for the stream to finish writing
+  await new Promise<void>((resolve, reject) => {
+    output.on('close', resolve);
+    output.on('error', reject);
+  });
+
+  return filePath;
+}
+
+function getPrettyOSName(): string {
+  const platform = os.platform();
+  const release = os.release(); // e.g. "10.0.22631"
+
+  if (platform === 'darwin') {
+    const major = parseInt(release.split('.')[0], 10);
+    // Darwin kernel 20 = macOS 11 Big Sur, 21 = 12 Monterey, etc.
+    const macVersion = major >= 20 ? major - 9 : null;
+    return macVersion ? `macOS ${macVersion} (${release})` : `macOS (${release})`;
+  }
+
+  if (platform === 'win32') {
+    const parts = release.split('.');
+    const build = parseInt(parts[2] || '0', 10);
+    // Windows 11 starts at build 22000
+    const winVersion = build >= 22000 ? '11' : '10';
+    return `Windows ${winVersion} (build ${build})`;
+  }
+
+  if (platform === 'linux') {
+    try {
+      const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+      const pretty = osRelease.match(/^PRETTY_NAME="?(.+?)"?$/m);
+      if (pretty) return pretty[1];
+    } catch {}
+    return `Linux ${release}`;
+  }
+
+  return `${platform} ${release}`;
+}
+

--- a/apps/agent/src/direct-connect/dolphin-config.ts
+++ b/apps/agent/src/direct-connect/dolphin-config.ts
@@ -13,6 +13,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { getSlippiUserJsonPaths } from '../config';
 import { getEffectiveLauncherDir } from '../launcher-path';
+import { directLog } from '../logger';
 
 // ---------------------------------------------------------------------------
 // Slippi Launcher Settings — shared by dolphin-config and dolphin-launcher
@@ -140,6 +141,7 @@ function getSlippiConfigDir(): string | null {
     if (fs.existsSync(jsonPath)) {
       const dir = path.dirname(jsonPath);
       console.log(`[direct-connect] Slippi config dir resolved via user.json: ${dir}`);
+      directLog.info(`Slippi config dir resolved via user.json: ${dir}`);
       return dir;
     }
   }
@@ -167,6 +169,7 @@ export function injectDirectCode(connectCode: string): void {
   const slippiDir = getSlippiConfigDir();
   if (!slippiDir) {
     console.warn('[direct-connect] Cannot find Slippi config directory — skipping code injection');
+    directLog.warn('Cannot find Slippi config directory — skipping code injection');
     return;
   }
 
@@ -187,4 +190,5 @@ export function injectDirectCode(connectCode: string): void {
   fs.mkdirSync(slippiDir, { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(codes));
   console.log(`[direct-connect] Injected ${connectCode} as most recent in direct-codes.json`);
+  directLog.info(`Injected ${connectCode} as most recent in direct-codes.json`);
 }

--- a/apps/agent/src/direct-connect/dolphin-launcher.ts
+++ b/apps/agent/src/direct-connect/dolphin-launcher.ts
@@ -21,6 +21,7 @@ import {
   detectDolphinVariant,
 } from './dolphin-config';
 import { DOLPHIN_PROCESS_NAMES } from '../config';
+import { directLog } from '../logger';
 
 const find = require('find-process') as (
   type: 'name',
@@ -87,6 +88,7 @@ export function getDolphinExePath(): string | null {
   const folder = path.join(launcherDir, `netplay${betaSuffix}`);
 
   console.log(`[dolphin-launcher] Detected variant=${variant}, folder=netplay${betaSuffix}`);
+  directLog.info(`Detected variant=${variant}, folder=netplay${betaSuffix}`);
 
   // Primary: honor the Launcher's configured variant & folder
   const primary = findExeInFolder(folder, variant);
@@ -99,6 +101,7 @@ export function getDolphinExePath(): string | null {
   const secondary = findExeInFolder(folder, otherVariant);
   if (secondary) {
     console.warn(`[dolphin-launcher] Expected ${variant} but found ${otherVariant} exe in ${folder}`);
+    directLog.warn(`Expected ${variant} but found ${otherVariant} exe in ${folder}`);
     return secondary;
   }
 
@@ -109,6 +112,7 @@ export function getDolphinExePath(): string | null {
     const fallback = findExeInFolder(altFolder, v);
     if (fallback) {
       console.warn(`[dolphin-launcher] Fell back to netplay${altSuffix} (${v})`);
+      directLog.warn(`Fell back to netplay${altSuffix} (${v})`);
       return fallback;
     }
   }
@@ -136,6 +140,7 @@ function getSlippiLauncherIsoPath(): string | null {
   const isoPath = settings?.settings?.isoPath;
   if (isoPath && typeof isoPath === 'string' && fs.existsSync(isoPath)) {
     console.log(`[dolphin-launcher] ISO from Slippi Launcher settings: ${isoPath}`);
+    directLog.info(`ISO from Slippi Launcher settings: ${isoPath}`);
     return isoPath;
   }
   return null;
@@ -180,6 +185,7 @@ export function getMeleeIsoPath(): string | null {
   // Last resort: return LastFilename even if it doesn't match, better than nothing
   if (lastFile) {
     console.warn(`[dolphin-launcher] LastFilename doesn't look like Melee: ${lastFile}`);
+    directLog.warn(`LastFilename doesn't look like Melee: ${lastFile}`);
     return lastFile;
   }
 
@@ -216,6 +222,7 @@ export async function killDolphin(): Promise<void> {
   if (pids.length === 0) return;
 
   console.log(`[dolphin-launcher] Killing Dolphin PIDs: ${pids.join(', ')}`);
+  directLog.info(`Killing Dolphin PIDs: ${pids.join(', ')}`);
   for (const pid of pids) {
     try { process.kill(pid, 'SIGTERM'); } catch {}
   }
@@ -226,6 +233,7 @@ export async function killDolphin(): Promise<void> {
     const remaining = await getDolphinPids();
     if (remaining.length === 0) {
       console.log('[dolphin-launcher] Dolphin stopped');
+      directLog.info('Dolphin stopped');
       return;
     }
   }
@@ -237,6 +245,7 @@ export async function killDolphin(): Promise<void> {
   }
   await sleep(500);
   console.log('[dolphin-launcher] Dolphin force-killed');
+  directLog.info('Dolphin force-killed');
 }
 
 export function launchDolphin(overrideUserDir?: string): void {
@@ -255,6 +264,7 @@ export function launchDolphin(overrideUserDir?: string): void {
   }
 
   console.log(`[dolphin-launcher] Launching: "${exePath}" ${args.map(a => `"${a}"`).join(' ')}`);
+  directLog.info(`Launching: "${exePath}" ${args.map(a => `"${a}"`).join(' ')}`);
 
   // macOS: use execFile to avoid spawn deadlocks in Dolphin's rendering
   // (matches how the Slippi Launcher handles this)

--- a/apps/agent/src/direct-connect/index.ts
+++ b/apps/agent/src/direct-connect/index.ts
@@ -9,6 +9,7 @@
 import { EventEmitter } from 'events';
 import { injectDirectCode } from './dolphin-config';
 import { isDolphinRunning, killDolphin, launchDolphin } from './dolphin-launcher';
+import { directLog } from '../logger';
 
 export type DirectConnectStatus =
   | 'idle'
@@ -73,6 +74,7 @@ export class DirectConnectService extends EventEmitter {
   private setStatus(status: DirectConnectStatus, message: string, connectCode?: string): void {
     this.currentStatus = status;
     console.log(`[direct-connect] ${status}: ${message}`);
+    directLog.info(`${status}: ${message}`);
     this.emit('status', { status, message, connectCode } as DirectConnectStatusEvent);
   }
 }

--- a/apps/agent/src/ipc.ts
+++ b/apps/agent/src/ipc.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, app, clipboard, dialog, ipcMain, shell } from 'electron';
 
+import { ipcLog } from './logger';
 import { getCurrentUser, handleAuthCallback, isAuthenticated, logout, startAuthFlow, startLocalAuthServer } from './auth';
 import { PRESENCE_STALE_THRESHOLD } from './config';
 import { getDirectConnectService } from './direct-connect';
@@ -165,6 +166,7 @@ async function upsertPlayerRating(connectCode: string, entry: RatingCacheEntry):
     });
   } catch (e) {
     console.error('upsertPlayerRating', connectCode, e);
+    ipcLog.error('upsertPlayerRating', connectCode, e);
   }
 }
 
@@ -283,6 +285,7 @@ export function registerIpcHandlers(
 
       if (staleCodes.length === 0) return;
       console.log(`[ratings] startup refresh: ${staleCodes.length} stale of ${allCodes.length} total`);
+      ipcLog.info(`startup refresh: ${staleCodes.length} stale of ${allCodes.length} total`);
 
       const CONCURRENCY = 5;
       for (let i = 0; i < staleCodes.length; i += CONCURRENCY) {
@@ -296,8 +299,10 @@ export function registerIpcHandlers(
         }
       }
       console.log(`[ratings] startup refresh complete`);
+      ipcLog.info('startup refresh complete');
     } catch (e) {
       console.error('[ratings] startup refresh failed', e);
+      ipcLog.error('startup refresh failed', e);
     }
   }, 10_000);
 
@@ -307,6 +312,7 @@ export function registerIpcHandlers(
       if (user) await cleanupExpiredInvites(user.id);
     } catch (e) {
       console.error('[invites] startup cleanup failed', e);
+      ipcLog.error('startup cleanup failed', e);
     }
   }, 5_000);
 
@@ -321,7 +327,7 @@ export function registerIpcHandlers(
     if (process.platform === 'linux') {
       const authDone = startLocalAuthServer();
       const url = await startAuthFlow();
-      authDone.then(onLocalAuth).catch((err) => console.error('[auth] Linux local auth failed:', err));
+      authDone.then(onLocalAuth).catch((err) => { console.error('[auth] Linux local auth failed:', err); ipcLog.error('Linux local auth failed:', err); });
       return url;
     }
 
@@ -336,9 +342,10 @@ export function registerIpcHandlers(
         ipcMain.removeListener('auth:deeplink-resolved', markResolved);
         if (deepLinkResolved) return;
         console.log('[auth] Deep link did not return in time, falling back to localhost callback');
+        ipcLog.info('Deep link did not return in time, falling back to localhost callback');
         const authDone = startLocalAuthServer();
         await startAuthFlow(true);
-        authDone.then(onLocalAuth).catch((err) => console.error('[auth] Windows fallback auth failed:', err));
+        authDone.then(onLocalAuth).catch((err) => { console.error('[auth] Windows fallback auth failed:', err); ipcLog.error('Windows fallback auth failed:', err); });
       }, 8_000);
 
       return url;
@@ -363,7 +370,7 @@ export function registerIpcHandlers(
       if (opts?.onLogout) await opts.onLogout();
       await logout();
       sendToRenderer('auth:changed', null);
-    } catch (e) { console.error('auth:logout', e); }
+    } catch (e) { console.error('auth:logout', e); ipcLog.error('auth:logout', e); }
   });
 
   ipcMain.handle('identity:get', () => {
@@ -392,7 +399,7 @@ export function registerIpcHandlers(
         .eq('friend_connect_code', identity.connectCode)
         .is('friend_id', null);
 
-      void verifyIdentity(identity).catch((e) => console.error('verifyIdentity', e));
+      void verifyIdentity(identity).catch((e) => { console.error('verifyIdentity', e); ipcLog.error('verifyIdentity', e); });
       return { ok: true, connectCode: identity.connectCode };
     } catch (e: any) { return { error: e.message }; }
   });
@@ -502,8 +509,9 @@ export function registerIpcHandlers(
         };
       });
       console.log(`[bench] friends:list total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} friends=${(t2-t1).toFixed(0)} cache=${(t3-t2).toFixed(0)} rows=${data.length})`);
+      ipcLog.info(`friends:list total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} friends=${(t2-t1).toFixed(0)} cache=${(t3-t2).toFixed(0)} rows=${data.length})`);
       return result;
-    } catch (e) { console.error('friends:list', e); return []; }
+    } catch (e) { console.error('friends:list', e); ipcLog.error('friends:list', e); return []; }
   });
 
   ipcMain.handle('friends:incoming', async () => {
@@ -570,8 +578,9 @@ export function registerIpcHandlers(
         };
       });
       console.log(`[bench] friends:incoming total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
+      ipcLog.info(`friends:incoming total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
       return result;
-    } catch (e) { console.error('friends:incoming', e); return []; }
+    } catch (e) { console.error('friends:incoming', e); ipcLog.error('friends:incoming', e); return []; }
   });
 
   ipcMain.handle('friends:accept', async (_e, requestId: string) => {
@@ -756,6 +765,7 @@ export function registerIpcHandlers(
       await supabase.from('event_log').insert({ user_id: userId, event_type: eventType, metadata });
     } catch (e: any) {
       console.warn('[event_log] Failed to log event:', eventType, e.message);
+      ipcLog.warn('Failed to log event:', eventType, e.message);
     }
   }
 
@@ -876,6 +886,7 @@ export function registerIpcHandlers(
         };
       });
       console.log(`[bench] invite:pending total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
+      ipcLog.info(`invite:pending total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
       return result;
     } catch { return []; }
   });
@@ -1010,6 +1021,7 @@ export function registerIpcHandlers(
         };
       });
       console.log(`[bench] invite:sent total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
+      ipcLog.info(`invite:sent total=${(performance.now()-t0).toFixed(0)}ms rows=${data.length}`);
       return result;
     } catch { return []; }
   });
@@ -1039,7 +1051,7 @@ export function registerIpcHandlers(
         .order('played_at', { ascending: false })
         .limit(limit);
       return data || [];
-    } catch (e) { console.error('opponents:list', e); return []; }
+    } catch (e) { console.error('opponents:list', e); ipcLog.error('opponents:list', e); return []; }
   });
 
   ipcMain.handle('opponents:page', async (_e, before: string, limit = 50) => {
@@ -1054,7 +1066,7 @@ export function registerIpcHandlers(
         .order('played_at', { ascending: false })
         .limit(limit);
       return data || [];
-    } catch (e) { console.error('opponents:page', e); return []; }
+    } catch (e) { console.error('opponents:page', e); ipcLog.error('opponents:page', e); return []; }
   });
 
   ipcMain.handle('opponents:latestTimestamp', async () => {
@@ -1069,7 +1081,7 @@ export function registerIpcHandlers(
         .limit(1)
         .maybeSingle();
       return data?.played_at ?? null;
-    } catch (e) { console.error('opponents:latestTimestamp', e); return null; }
+    } catch (e) { console.error('opponents:latestTimestamp', e); ipcLog.error('opponents:latestTimestamp', e); return null; }
   });
 
   ipcMain.handle('stats:playerCount', async () => {
@@ -1109,7 +1121,7 @@ export function registerIpcHandlers(
         .order('in_game_seconds', { ascending: false })
         .gt('in_game_seconds', 0)
         .limit(limit);
-      if (error) { console.error('leaderboard:top', error.message); return []; }
+      if (error) { console.error('leaderboard:top', error.message); ipcLog.error('leaderboard:top', error.message); return []; }
       const rows = (data || []).map((row: any) => ({
         userId: row.user_id,
         profiles: row.profiles,
@@ -1134,7 +1146,7 @@ export function registerIpcHandlers(
           rankChange: yRank - todayRank,
         };
       });
-    } catch (e) { console.error('leaderboard:top', e); return []; }
+    } catch (e) { console.error('leaderboard:top', e); ipcLog.error('leaderboard:top', e); return []; }
   });
 
   ipcMain.handle('presence:online', () => getOnlineUsers());
@@ -1184,8 +1196,9 @@ export function registerIpcHandlers(
         result[code] = resolvePresenceRow(row as any, PRESENCE_STALE_THRESHOLD, now);
       }
       console.log(`[bench] presence:friendStatuses total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} friends=${(t2-t1).toFixed(0)} presence=${(t3-t2).toFixed(0)} rows=${data.length})`);
+      ipcLog.info(`presence:friendStatuses total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} friends=${(t2-t1).toFixed(0)} presence=${(t3-t2).toFixed(0)} rows=${data.length})`);
       return result;
-    } catch (e) { console.error('presence:friendStatuses', e); return {}; }
+    } catch (e) { console.error('presence:friendStatuses', e); ipcLog.error('presence:friendStatuses', e); return {}; }
   });
 
   let discoverInFlight: Promise<any[]> | null = null;
@@ -1404,8 +1417,9 @@ export function registerIpcHandlers(
       }));
 
       console.log(`[bench] discover:list total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} context=${(t2-t1).toFixed(0)} presence=${(t3-t2).toFixed(0)} profiles=${(t4-t3).toFixed(0)} ratings=${(t5-t4).toFixed(0)} matches=${(t6-t5).toFixed(0)} candidates=${candidateIds.length} results=${withMutuals.length} nullRatings=${withMutuals.filter((r: any) => r.rating == null).length})`);
+      ipcLog.info(`discover:list total=${(performance.now()-t0).toFixed(0)}ms (auth=${(t1-t0).toFixed(0)} context=${(t2-t1).toFixed(0)} presence=${(t3-t2).toFixed(0)} profiles=${(t4-t3).toFixed(0)} ratings=${(t5-t4).toFixed(0)} matches=${(t6-t5).toFixed(0)} candidates=${candidateIds.length} results=${withMutuals.length} nullRatings=${withMutuals.filter((r: any) => r.rating == null).length})`);
       return withMutuals;
-    } catch (e) { console.error('discover:list', e); return []; }
+    } catch (e) { console.error('discover:list', e); ipcLog.error('discover:list', e); return []; }
     })();
     try { return await discoverInFlight; } finally { discoverInFlight = null; }
   });
@@ -1744,7 +1758,7 @@ export function registerIpcHandlers(
           blockedAt: b.created_at,
         };
       });
-    } catch (e) { console.error('block:list', e); return []; }
+    } catch (e) { console.error('block:list', e); ipcLog.error('block:list', e); return []; }
   });
 
   ipcMain.handle('auth:checkBlacklist', async () => {
@@ -1817,7 +1831,7 @@ export function registerIpcHandlers(
           gameCount: c.gameCount,
         })).filter((c: any) => c.character != null),
       };
-    } catch (e: any) { console.error('slippi:lookup', e); return null; }
+    } catch (e: any) { console.error('slippi:lookup', e); ipcLog.error('slippi:lookup', e); return null; }
   });
 
   ipcMain.handle('config:broadcast', async () => {
@@ -1863,6 +1877,7 @@ export function registerIpcHandlers(
       const { data, error } = await supabase.from('patreon_public_supporters').select('connect_code');
       if (error) {
         console.warn('[patreon] listPublicSupporterCodes:', error.message);
+        ipcLog.warn('listPublicSupporterCodes:', error.message);
         return [];
       }
       return (data ?? [])
@@ -1877,12 +1892,14 @@ export function registerIpcHandlers(
     const raw = typeof url === 'string' ? url.trim() : '';
     if (!raw) {
       console.warn('[shell] openExternal: empty url');
+      ipcLog.warn('openExternal: empty url');
       return;
     }
     try {
       await shell.openExternal(raw);
     } catch (e) {
       console.error('[shell] openExternal failed:', raw, e);
+      ipcLog.error('openExternal failed:', raw, e);
     }
   });
 
@@ -1901,6 +1918,7 @@ export function registerIpcHandlers(
       exec('reg query HKCR\\discord /ve', { timeout: 3000 }, (err: any, stdout: string) => {
         discordProtocolSupported = !err && stdout.includes('URL:');
         console.log('[discord] protocol supported:', discordProtocolSupported);
+        ipcLog.info('protocol supported:', discordProtocolSupported);
       });
     } else if (process.platform === 'darwin') {
       discordProtocolSupported = true;
@@ -1968,6 +1986,7 @@ export function registerIpcHandlers(
   ipcMain.handle('cashbox:getSnapshot', async () => {
     if (_snapshotInflight) {
       console.log('[cashbox] dedup: sharing in-flight snapshot request');
+      ipcLog.info('dedup: sharing in-flight snapshot request');
       return _snapshotInflight;
     }
 
@@ -2003,6 +2022,7 @@ export function registerIpcHandlers(
         }
         const sggToken = await getStartGgUserToken();
         console.log('[cashbox] token source:', sggToken ? 'oauth (user-linked)' : 'env (START_GG_TOKEN fallback)');
+        ipcLog.info('token source:', sggToken ? 'oauth (user-linked)' : 'env (START_GG_TOKEN fallback)');
         const snap = await getCashboxSnapshot(code, sggToken);
         if (snap.ok) {
           await enrichCashboxFriendliesOpponent(snap, user?.id ?? null, code);
@@ -2012,6 +2032,7 @@ export function registerIpcHandlers(
         return snap;
       } catch (e: any) {
         console.error('cashbox:getSnapshot', e);
+        ipcLog.error('cashbox:getSnapshot', e);
         return { ok: false as const, reason: 'api' as const, message: e?.message || 'Unknown error' };
       }
     })();
@@ -2045,6 +2066,7 @@ export function registerIpcHandlers(
       return { ok: true as const, friendlies: result };
     } catch (e: any) {
       console.error('cashbox:lookupOpponent', e);
+      ipcLog.error('cashbox:lookupOpponent', e);
       return { ok: false as const, message: e?.message || 'Unknown error' };
     }
   });
@@ -2214,5 +2236,19 @@ export function registerIpcHandlers(
       connected: isStartGgConnected(),
       ...getStartGgUserInfo(),
     };
+  });
+
+  ipcMain.handle('diagnostics:export', async () => {
+    const { exportDiagnostics } = await import('./diagnostics');
+    return exportDiagnostics();
+  });
+
+  ipcMain.handle('diagnostics:openLogs', () => {
+    const log = require('electron-log/main');
+    const logFile = log.transports.file.getFile();
+    if (logFile?.path) {
+      const dir = require('path').dirname(logFile.path);
+      shell.openPath(dir);
+    }
   });
 }

--- a/apps/agent/src/ipc.ts
+++ b/apps/agent/src/ipc.ts
@@ -459,13 +459,14 @@ export function registerIpcHandlers(
     const t0 = performance.now();
     try {
       const user = await getCurrentUser();
-      if (!user) return [];
+      if (!user) { console.log('[friends:list] no authenticated user'); return []; }
       const t1 = performance.now();
-      const { data } = await supabase
+      const { data, error: friendsError } = await supabase
         .from('friends')
         .select('id, friend_id, friend_connect_code, status, created_at, profiles!friends_friend_id_fkey(connect_code, display_name, discord_username, discord_id, avatar_url, region, chosen_region, hide_region, hide_discord_unless_friends, hide_avatar, main_character, secondary_character, top_characters)')
         .eq('user_id', user.id);
-      if (!data) return [];
+      if (friendsError) console.error('[friends:list] query error', friendsError);
+      if (!data) { console.log(`[friends:list] no data for user ${user.id}`); return []; }
       const t2 = performance.now();
 
       const codes = data
@@ -1428,6 +1429,102 @@ export function registerIpcHandlers(
     try { return await discoverInFlight; } finally { discoverInFlight = null; }
   });
 
+  // --- Mutuals ---
+
+  ipcMain.handle('mutuals:list', async () => {
+    try {
+      const user = await getCurrentUser();
+      if (!user) { console.log('[mutuals:list] no authenticated user'); return []; }
+      const t0 = performance.now();
+
+      // Read precomputed mutual counts for this user
+      const { data: rows, error: mfcError } = await supabase
+        .from('mutual_friend_counts')
+        .select('user_a, user_b, mutual_count')
+        .or(`user_a.eq.${user.id},user_b.eq.${user.id}`)
+        .order('mutual_count', { ascending: false })
+        .limit(100);
+      if (mfcError) console.error('[mutuals:list] mfc query error', mfcError);
+      if (!rows || rows.length === 0) { console.log(`[mutuals:list] no mutual_friend_counts rows for user ${user.id}`); return []; }
+
+      // Collect the "other" user ids
+      const otherIds = rows.map((r: any) => r.user_a === user.id ? r.user_b : r.user_a);
+      const countMap = new Map<string, number>();
+      rows.forEach((r: any) => {
+        const otherId = r.user_a === user.id ? r.user_b : r.user_a;
+        countMap.set(otherId, r.mutual_count);
+      });
+
+      // Fetch profiles
+      const { data: profiles } = await supabase.from('profiles').select('id, connect_code, display_name, avatar_url, hide_avatar, hide_mutual_friends, top_characters, main_character, region, chosen_region, hide_region, discord_username, discord_id, hide_discord_unless_friends').in('id', otherIds);
+
+      // Fetch ratings (keyed by connect_code)
+      const codes = (profiles || []).map((p: any) => p.connect_code).filter(Boolean);
+      const { data: ratings } = codes.length > 0
+        ? await supabase.from('player_ratings').select('connect_code, effective_rating').in('connect_code', codes)
+        : { data: [] };
+
+      const ratingsMap: Record<string, number> = {};
+      (ratings || []).forEach((r: any) => { if (r.effective_rating != null) ratingsMap[r.connect_code] = r.effective_rating; });
+
+      // Check which of these users are already friends
+      const { data: friendRows } = await supabase
+        .from('friends')
+        .select('friend_id, friend_connect_code, status')
+        .eq('user_id', user.id)
+        .in('friend_connect_code', (profiles || []).map((p: any) => p.connect_code).filter(Boolean));
+      const friendStatusMap = new Map<string, string>();
+      (friendRows || []).forEach((f: any) => {
+        if (f.friend_connect_code) friendStatusMap.set(f.friend_connect_code, f.status);
+      });
+
+      const result = (profiles || [])
+        .filter((p: any) => !p.hide_mutual_friends && friendStatusMap.get(p.connect_code) !== 'accepted')
+        .map((p: any) => {
+          const slippi: { characterId: number; gameCount: number }[] = Array.isArray(p.top_characters) ? p.top_characters : [];
+          const topCharacters: { characterId: number; gameCount: number }[] = [];
+          if (p.main_character != null) topCharacters.push({ characterId: p.main_character, gameCount: 0 });
+          else if (slippi[0]) topCharacters.push(slippi[0]);
+          return {
+            userId: p.id,
+            connectCode: p.connect_code,
+            displayName: p.display_name || null,
+            discordUsername: p.hide_discord_unless_friends ? null : (p.discord_username || null),
+            discordId: p.hide_discord_unless_friends ? null : (p.discord_id || null),
+            avatarUrl: p.hide_avatar ? null : (p.avatar_url || null),
+            rating: ratingsMap[p.connect_code] ?? null,
+            topCharacters,
+            region: p.hide_region ? null : (p.chosen_region || p.region || null),
+            mutualFriendCount: countMap.get(p.id) ?? 0,
+            friendStatus: friendStatusMap.get(p.connect_code) || null,
+          };
+        })
+        .sort((a: any, b: any) => (b.mutualFriendCount ?? 0) - (a.mutualFriendCount ?? 0));
+
+      console.log(`[bench] mutuals:list total=${(performance.now()-t0).toFixed(0)}ms rows=${result.length}`);
+      ipcLog.info(`mutuals:list total=${(performance.now()-t0).toFixed(0)}ms rows=${result.length}`);
+      return result;
+    } catch (e) { console.error('mutuals:list', e); ipcLog.error('mutuals:list', e); return []; }
+  });
+
+  ipcMain.handle('mutuals:for-player', async (_e, targetUserId: string) => {
+    try {
+      const user = await getCurrentUser();
+      if (!user) return [];
+      const { data, error } = await supabase.rpc('get_mutual_friends', { p_target_id: targetUserId });
+      if (error) { console.error('mutuals:for-player rpc error', error); return []; }
+      return (data || []).map((r: any) => ({
+        userId: r.id,
+        connectCode: r.connect_code,
+        displayName: r.display_name || null,
+        avatarUrl: r.avatar_url || null,
+        rating: r.rating != null ? Number(r.rating) : null,
+        topCharacters: Array.isArray(r.top_characters) ? r.top_characters : [],
+        region: r.region || null,
+      }));
+    } catch (e) { console.error('mutuals:for-player', e); ipcLog.error('mutuals:for-player', e); return []; }
+  });
+
   const VALID_NUDGE_MESSAGES = ['GGs', 'one more', 'gtg', 'you play so hot and cool', 'that was sick', "you're cracked", "i'm cracked", "i'm so high", 'check discord', 'hi', 'Down in 5-15 min', 'Sorry, another time', 'Looking for different matchup', 'Message me on Discord'];
 
   ipcMain.handle('nudge:send', async (_e, receiverConnectCode: string, message: string) => {
@@ -1613,8 +1710,8 @@ export function registerIpcHandlers(
   ipcMain.handle('privacy:get', async () => {
     try {
       const user = await getCurrentUser();
-      if (!user) return { hideRegion: false, hideDiscordUnlessFriends: false, hideAvatar: false, hideConnectionType: false, hideOnlineStatus: false, disableFriendRequests: false, chosenRegion: null };
-      const { data } = await supabase.from('profiles').select('hide_region, hide_discord_unless_friends, hide_avatar, hide_connection_type, show_online_status, disable_friend_requests, chosen_region').eq('id', user.id).single();
+      if (!user) return { hideRegion: false, hideDiscordUnlessFriends: false, hideAvatar: false, hideConnectionType: false, hideOnlineStatus: false, disableFriendRequests: false, hideMutualFriends: false, chosenRegion: null };
+      const { data } = await supabase.from('profiles').select('hide_region, hide_discord_unless_friends, hide_avatar, hide_connection_type, show_online_status, disable_friend_requests, hide_mutual_friends, chosen_region').eq('id', user.id).single();
       const hideConn = data?.hide_connection_type ?? false;
       const hideOnline = !(data?.show_online_status ?? true);
       setHideConnectionType(hideConn);
@@ -1626,12 +1723,13 @@ export function registerIpcHandlers(
         hideConnectionType: hideConn,
         hideOnlineStatus: hideOnline,
         disableFriendRequests: data?.disable_friend_requests ?? false,
+        hideMutualFriends: data?.hide_mutual_friends ?? false,
         chosenRegion: data?.chosen_region ?? null,
       };
     } catch { return { hideRegion: false, hideDiscordUnlessFriends: false, hideAvatar: false, hideConnectionType: false, hideOnlineStatus: false, disableFriendRequests: false, chosenRegion: null }; }
   });
 
-  ipcMain.handle('privacy:update', async (_e, partial: { hideRegion?: boolean; hideDiscordUnlessFriends?: boolean; hideAvatar?: boolean; hideConnectionType?: boolean; hideOnlineStatus?: boolean; disableFriendRequests?: boolean }) => {
+  ipcMain.handle('privacy:update', async (_e, partial: { hideRegion?: boolean; hideDiscordUnlessFriends?: boolean; hideAvatar?: boolean; hideConnectionType?: boolean; hideOnlineStatus?: boolean; disableFriendRequests?: boolean; hideMutualFriends?: boolean }) => {
     try {
       const user = await getCurrentUser();
       if (!user) return { error: 'Not authenticated' };
@@ -1648,6 +1746,7 @@ export function registerIpcHandlers(
         setHideOnlineStatus(partial.hideOnlineStatus);
       }
       if (partial.disableFriendRequests !== undefined) update.disable_friend_requests = partial.disableFriendRequests;
+      if (partial.hideMutualFriends !== undefined) update.hide_mutual_friends = partial.hideMutualFriends;
       const { error } = await supabase.from('profiles').update(update).eq('id', user.id);
       if (error) return { error: error.message };
       return { ok: true };

--- a/apps/agent/src/logger.ts
+++ b/apps/agent/src/logger.ts
@@ -1,0 +1,24 @@
+import log from 'electron-log/main';
+
+log.initialize();
+log.transports.file.level = 'info';
+log.transports.file.maxSize = 5 * 1024 * 1024; // 5 MB, rotates to .old
+log.errorHandler.startCatching();
+
+export default log;
+
+export const authLog     = log.scope('auth');
+export const presenceLog = log.scope('presence');
+export const watcherLog  = log.scope('watcher');
+export const identityLog = log.scope('identity');
+export const mainLog     = log.scope('main');
+export const ipcLog      = log.scope('ipc');
+export const trayLog     = log.scope('tray');
+export const updaterLog  = log.scope('updater');
+export const chatLog     = log.scope('chat');
+export const geoLog      = log.scope('geo');
+export const notifLog    = log.scope('notifications');
+export const cashboxLog  = log.scope('cashbox');
+export const startggLog  = log.scope('startgg');
+export const directLog   = log.scope('direct-connect');
+export const settingsLog = log.scope('settings');

--- a/apps/agent/src/main.ts
+++ b/apps/agent/src/main.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { BrowserWindow, Menu, app, ipcMain, screen, shell } from 'electron';
+import { mainLog } from './logger';
 import {
   getCurrentUser, handleAuthCallback, isAuthenticated,
   listenForTokenRefresh, logout, restoreSession, startAuthFlow,
@@ -64,7 +65,7 @@ function loadDotEnvFromAppDir(): void {
         parseDotEnvContent(fs.readFileSync(envPath, 'utf8'));
       }
     }
-  } catch (e) { console.error('loadDotEnvFromAppDir', e); }
+  } catch (e) { console.error('loadDotEnvFromAppDir', e); mainLog.error('loadDotEnvFromAppDir', e); }
 }
 
 async function fetchGeoWithFallback(): Promise<{ lat: number; lon: number; region: string } | null> {
@@ -108,6 +109,7 @@ async function fetchGeoWithFallback(): Promise<{ lat: number; lon: number; regio
 
   if (results.length === 0) {
     console.warn('[main] all geolocation services failed');
+    mainLog.warn('all geolocation services failed');
     return null;
   }
 
@@ -161,6 +163,11 @@ function createMainWindow(): BrowserWindow {
       backgroundThrottling: true,
     },
   });
+  //WIN DEV only:
+  // win.webContents.setWindowOpenHandler(({ url }) => {
+  //   shell.openExternal(url);
+  //   return { action: 'deny' };
+  // });
 
   let boundsTimer: ReturnType<typeof setTimeout> | null = null;
   const persistBounds = () => {
@@ -169,6 +176,12 @@ function createMainWindow(): BrowserWindow {
   };
   win.on('resize', persistBounds);
   win.on('move', persistBounds);
+
+  win.webContents.on('before-input-event', (_e, input) => {
+    if (input.type === 'keyDown' && input.key === 'F12') {
+      win.webContents.toggleDevTools();
+    }
+  });
 
   if (process.env.NODE_ENV === 'development' || process.argv.includes('--dev')) {
     win.loadURL('http://localhost:5173');
@@ -200,7 +213,7 @@ async function stopAgentServices(): Promise<void> {
   knownPlayInviteIds.clear();
   knownNudgeIds.clear();
   unreadNudgeCount = 0;
-  try { await stopPresenceLoop(); } catch (e) { console.error('stopPresenceLoop', e); }
+  try { await stopPresenceLoop(); } catch (e) { console.error('stopPresenceLoop', e); mainLog.error('stopPresenceLoop', e); }
   stopWatcher();
 }
 
@@ -220,7 +233,10 @@ async function pollAllNotifications(userId: string): Promise<void> {
     ]);
     firstPollDone = true;
     const ms = performance.now() - t0;
-    if (ms > 200) console.log(`[perf] pollAllNotifications took ${ms.toFixed(0)}ms`);
+    if (ms > 200) {
+      console.log(`[perf] pollAllNotifications took ${ms.toFixed(0)}ms`);
+      mainLog.info(`pollAllNotifications took ${ms.toFixed(0)}ms`);
+    }
   } finally {
     pollInFlight = false;
     updateTrayStatus();
@@ -259,7 +275,7 @@ async function pollFriendOnlineStatuses(userId: string, suppressNotifs = false):
       }
       previousFriendStatuses.set(code, newStatus);
     }
-  } catch (e) { console.error('[main] friend status poll failed', e); }
+  } catch (e) { console.error('[main] friend status poll failed', e); mainLog.error('friend status poll failed', e); }
 }
 
 async function pollIncomingFriendRequests(userId: string, suppressNotifs = false): Promise<void> {
@@ -296,7 +312,7 @@ async function pollIncomingFriendRequests(userId: string, suppressNotifs = false
         }
       });
     }
-  } catch (e) { console.error('[main] incoming request poll failed', e); }
+  } catch (e) { console.error('[main] incoming request poll failed', e); mainLog.error('incoming request poll failed', e); }
 }
 
 async function pollPlayInvites(userId: string): Promise<void> {
@@ -343,7 +359,7 @@ async function pollPlayInvites(userId: string): Promise<void> {
     if (didNotify) {
       sendToRenderer('invites:refresh', {});
     }
-  } catch (e) { console.error('[main] play invite poll failed', e); }
+  } catch (e) { console.error('[main] play invite poll failed', e); mainLog.error('play invite poll failed', e); }
 }
 
 async function pollNudges(userId: string, suppressNotifs = false): Promise<void> {
@@ -387,13 +403,14 @@ async function pollNudges(userId: string, suppressNotifs = false): Promise<void>
       }
     }
     sendToRenderer('nudge:unreadCount', unreadNudgeCount);
-  } catch (e) { console.error('[main] nudge poll failed', e); }
+  } catch (e) { console.error('[main] nudge poll failed', e); mainLog.error('nudge poll failed', e); }
 }
 
 async function startAgentServices(identity: SlippiIdentity, userId: string): Promise<void> {
   const key = `${userId}:${identity.connectCode}`;
   if (activeServiceKey === key) {
     console.log('[main] services already running for', identity.connectCode, '— skipping restart');
+    mainLog.info('services already running for', identity.connectCode, '— skipping restart');
     return;
   }
   await stopAgentServices();
@@ -403,6 +420,7 @@ async function startAgentServices(identity: SlippiIdentity, userId: string): Pro
 
   setIdentityMismatchHandler(async (mismatch) => {
     console.warn('[main] Identity mismatch — stopping services and notifying renderer');
+    mainLog.warn('Identity mismatch — stopping services and notifying renderer');
     await stopAgentServices();
     sendToRenderer('identity:mismatch', mismatch);
   });
@@ -413,7 +431,7 @@ async function startAgentServices(identity: SlippiIdentity, userId: string): Pro
       setLastOpponent(info.connectCode, info.characterId, info.gameMode);
       sendToRenderer('opponent:new', info);
       updateTrayStatus();
-    } catch (e) { console.error('opponent callback', e); }
+    } catch (e) { console.error('opponent callback', e); mainLog.error('opponent callback', e); }
   });
   setGameThrottling(st.reduceBackgroundActivity);
   await startPresenceLoop(identity.connectCode, identity.displayName || identity.connectCode, userId, st.replayDir);
@@ -436,6 +454,7 @@ async function startAgentServices(identity: SlippiIdentity, userId: string): Pro
     const interval = inGame ? NOTIF_POLL_IN_GAME : NOTIF_POLL_NORMAL;
     friendPollTimer = setInterval(() => void pollAllNotifications(userId), interval);
     console.log(`[main] Game ${inGame ? 'active' : 'idle'} — notification poll interval: ${interval / 1000}s`);
+    mainLog.info(`Game ${inGame ? 'active' : 'idle'} — notification poll interval: ${interval / 1000}s`);
   });
 }
 
@@ -449,6 +468,7 @@ async function refreshAgentState(): Promise<void> {
     if (authed && identity && user) {
       if (identity.staleAccount) {
         console.warn(`[main] identity is stale (user.json uid ≠ Launcher activeId) — stopping services`);
+        mainLog.warn('identity is stale (user.json uid ≠ Launcher activeId) — stopping services');
         await stopAgentServices();
         sendToRenderer('identity:staleAccount', { connectCode: identity.connectCode });
         updateTrayStatus();
@@ -464,6 +484,7 @@ async function refreshAgentState(): Promise<void> {
 
       if (existingClaim?.verified) {
         console.warn(`[main] connect code ${identity.connectCode} is already claimed by another verified user`);
+        mainLog.warn(`connect code ${identity.connectCode} is already claimed by another verified user`);
         await stopAgentServices();
         sendToRenderer('identity:codeClaimed', { connectCode: identity.connectCode });
         updateTrayStatus();
@@ -493,18 +514,18 @@ async function refreshAgentState(): Promise<void> {
           profileUpdate.longitude = geo.lon;
           profileUpdate.region = geo.region;
         }
-      } catch (e) { console.warn('[main] geolocation lookup failed:', e); }
+      } catch (e) { console.warn('[main] geolocation lookup failed:', e); mainLog.warn('geolocation lookup failed:', e); }
 
       const { error: syncErr } = await supabase.from('profiles').update(profileUpdate).eq('id', user.id);
-      if (syncErr) console.error('[main] profile sync failed:', syncErr.message);
-      else console.log('[main] profile synced:', identity.connectCode);
+      if (syncErr) { console.error('[main] profile sync failed:', syncErr.message); mainLog.error('profile sync failed:', syncErr.message); }
+      else { console.log('[main] profile synced:', identity.connectCode); mainLog.info('profile synced:', identity.connectCode); }
 
       await startAgentServices(identity, user.id);
     } else {
       await stopAgentServices();
     }
     updateTrayStatus();
-  } catch (e) { console.error('refreshAgentState', e); } finally { refreshLock = false; }
+  } catch (e) { console.error('refreshAgentState', e); mainLog.error('refreshAgentState', e); } finally { refreshLock = false; }
 }
 
 async function handleDeepLink(url: string): Promise<void> {
@@ -519,7 +540,7 @@ async function handleDeepLink(url: string): Promise<void> {
     const user = await getCurrentUser();
     sendToRenderer('auth:changed', user);
     await refreshAgentState();
-  } catch (e) { console.error('handleDeepLink', e); }
+  } catch (e) { console.error('handleDeepLink', e); mainLog.error('handleDeepLink', e); }
 }
 
 // --- App lifecycle ---
@@ -532,7 +553,7 @@ if (process.platform === 'win32') {
 
 const isDev = process.env.NODE_ENV === 'development' || process.argv.includes('--dev');
 
-if (!isDev && !app.requestSingleInstanceLock()) {
+if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
   app.on('second-instance', (_e, argv) => {
@@ -561,7 +582,7 @@ app.on('before-quit', async (e) => {
     (app as any).isQuitting = true;
     try {
       await pushOfflineAndStop();
-    } catch (err) { console.error('before-quit cleanup failed', err); }
+    } catch (err) { console.error('before-quit cleanup failed', err); mainLog.error('before-quit cleanup failed', err); }
     destroyTray();
     app.quit();
   }
@@ -571,6 +592,7 @@ app.whenReady().then(async () => {
   try {
     Menu.setApplicationMenu(null);
     loadDotEnvFromAppDir();
+    mainLog.info('App starting', { version: app.getVersion(), platform: process.platform, arch: process.arch });
     const st0 = getSettings();
     app.setLoginItemSettings({ openAtLogin: st0.autoLaunch, openAsHidden: true });
 
@@ -645,7 +667,7 @@ app.whenReady().then(async () => {
         updateTrayStatus();
       } catch {}
     }, 10_000);
-  } catch (e) { console.error('app.whenReady', e); }
+  } catch (e) { console.error('app.whenReady', e); mainLog.error('app.whenReady', e); }
 });
 
 app.on('window-all-closed', () => {

--- a/apps/agent/src/main.ts
+++ b/apps/agent/src/main.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { BrowserWindow, app, ipcMain, screen, shell } from 'electron';
+import { BrowserWindow, Menu, app, ipcMain, screen, shell } from 'electron';
 import {
   getCurrentUser, handleAuthCallback, isAuthenticated,
   listenForTokenRefresh, logout, restoreSession, startAuthFlow,
@@ -569,6 +569,7 @@ app.on('before-quit', async (e) => {
 
 app.whenReady().then(async () => {
   try {
+    Menu.setApplicationMenu(null);
     loadDotEnvFromAppDir();
     const st0 = getSettings();
     app.setLoginItemSettings({ openAtLogin: st0.autoLaunch, openAsHidden: true });

--- a/apps/agent/src/main.ts
+++ b/apps/agent/src/main.ts
@@ -163,11 +163,11 @@ function createMainWindow(): BrowserWindow {
       backgroundThrottling: true,
     },
   });
-  //WIN DEV only:
-  // win.webContents.setWindowOpenHandler(({ url }) => {
-  //   shell.openExternal(url);
-  //   return { action: 'deny' };
-  // });
+  // WIN DEV only:
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
 
   let boundsTimer: ReturnType<typeof setTimeout> | null = null;
   const persistBounds = () => {

--- a/apps/agent/src/notifications.ts
+++ b/apps/agent/src/notifications.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, Notification } from 'electron';
 import { getSettings } from './settings';
 import { getCurrentStatus } from './presence';
+import { notifLog } from './logger';
 
 const NOTIF_COOLDOWN_MS = 60_000;
 const recentFriendNotifs = new Map<string, number>();
@@ -43,6 +44,7 @@ export function showFriendOnlineNotification(
     n.show();
   } catch (e) {
     console.error('showFriendOnlineNotification failed', e);
+    notifLog.error('showFriendOnlineNotification failed', e);
   }
 }
 
@@ -65,6 +67,7 @@ export function showFriendRequestNotification(
     playNotificationSound();
   } catch (e) {
     console.error('showFriendRequestNotification failed', e);
+    notifLog.error('showFriendRequestNotification failed', e);
   }
 }
 
@@ -87,6 +90,7 @@ export function showPlayInviteNotification(
     playNotificationSound();
   } catch (e) {
     console.error('showPlayInviteNotification failed', e);
+    notifLog.error('showPlayInviteNotification failed', e);
   }
 }
 
@@ -116,6 +120,7 @@ export function showNudgeNotification(
     playNotificationSound();
   } catch (e) {
     console.error('showNudgeNotification failed', e);
+    notifLog.error('showNudgeNotification failed', e);
   }
 }
 
@@ -127,5 +132,6 @@ export function showTestNotification(): void {
     }
   } catch (e) {
     console.error('showTestNotification failed', e);
+    notifLog.error('showTestNotification failed', e);
   }
 }

--- a/apps/agent/src/preload.ts
+++ b/apps/agent/src/preload.ts
@@ -53,6 +53,9 @@ const api = {
 
   discoverPlayers: (opts?: { characterIds?: number[]; minElo?: number; maxElo?: number }) => ipcRenderer.invoke('discover:list', opts),
 
+  getMutualConnections: () => ipcRenderer.invoke('mutuals:list'),
+  getMutualFriendsFor: (targetUserId: string) => ipcRenderer.invoke('mutuals:for-player', targetUserId),
+
   getLeaderboard: (limit?: number) => ipcRenderer.invoke('leaderboard:top', limit) as Promise<{ userId: string; connectCode: string; displayName: string; avatarUrl: string | null; mainCharacter: number | null; inGameSeconds: number; rankChange: number }[]>,
 
   getPlayerCount: () => ipcRenderer.invoke('stats:playerCount'),

--- a/apps/agent/src/preload.ts
+++ b/apps/agent/src/preload.ts
@@ -208,6 +208,9 @@ const api = {
   testNotification: () => ipcRenderer.invoke('notifications:test'),
   reportDocumentHidden: (hidden: boolean) => ipcRenderer.send('visibility:document', hidden),
   onGameActive: (cb: (active: boolean) => void): Unsubscribe => onEvent('game:active', cb),
+
+  exportDiagnostics: () => ipcRenderer.invoke('diagnostics:export') as Promise<string | null>,
+  openLogsDirectory: () => ipcRenderer.invoke('diagnostics:openLogs'),
 };
 
 export type ElectronAPI = typeof api;

--- a/apps/agent/src/presence.ts
+++ b/apps/agent/src/presence.ts
@@ -19,6 +19,7 @@ import {
   shouldWriteDb as _shouldWriteDb,
   type PresenceStatus,
 } from './presence-logic';
+import { presenceLog } from './logger';
 import { supabase } from './supabase';
 
 export type { PresenceStatus };
@@ -286,7 +287,7 @@ export function onGameActiveChange(cb: GameActiveCallback): () => void {
 
 function emitGameActive(inGame: boolean): void {
   for (const cb of gameActiveCallbacks) {
-    try { cb(inGame); } catch (e) { console.error('gameActiveCallback', e); }
+    try { cb(inGame); } catch (e) { console.error('gameActiveCallback', e); presenceLog.error('gameActiveCallback', e); }
   }
 }
 
@@ -450,7 +451,7 @@ export function onLocalStatusChange(cb: LocalStatusCallback): () => void {
 
 function emitPresenceSync(): void {
   for (const cb of syncCallbacks) {
-    try { cb(onlineUsers); } catch (e) { console.error('presenceSyncCallback', e); }
+    try { cb(onlineUsers); } catch (e) { console.error('presenceSyncCallback', e); presenceLog.error('presenceSyncCallback', e); }
   }
 }
 
@@ -466,7 +467,7 @@ function emitLocalStatus(): void {
     gameMode: currentStatus === 'in-game' ? lastGameMode : null,
   };
   for (const cb of localStatusCallbacks) {
-    try { cb(info); } catch (e) { console.error('localStatusCallback', e); }
+    try { cb(info); } catch (e) { console.error('localStatusCallback', e); presenceLog.error('localStatusCallback', e); }
   }
 }
 
@@ -493,7 +494,7 @@ function extractOnlineUsers(): OnlineUser[] {
       }
     }
     return users;
-  } catch (e) { console.error('extractOnlineUsers', e); return []; }
+  } catch (e) { console.error('extractOnlineUsers', e); presenceLog.error('extractOnlineUsers', e); return []; }
 }
 
 function getProcessSnapshot(): Promise<string> {
@@ -576,10 +577,12 @@ async function pushPresence(
         if (error.message.includes('row-level security')) {
           if (now - lastRlsWarning > 60_000) {
             console.warn('[presence] RLS rejection — auth session may have expired. Will retry silently.');
+            presenceLog.warn('RLS rejection — auth session may have expired. Will retry silently.');
             lastRlsWarning = now;
           }
         } else {
           console.error('[presence] DB upsert failed:', error.message);
+          presenceLog.error('DB upsert failed:', error.message);
           if (error.message.includes('opponent_code') || error.message.includes('playing_since')) {
             const { error: retryErr } = await supabase.from('presence_log').upsert(
               {
@@ -591,7 +594,10 @@ async function pushPresence(
               },
               { onConflict: 'user_id' },
             );
-            if (retryErr) console.error('[presence] DB upsert retry failed:', retryErr.message);
+            if (retryErr) {
+              console.error('[presence] DB upsert retry failed:', retryErr.message);
+              presenceLog.error('DB upsert retry failed:', retryErr.message);
+            }
           }
         }
       } else {
@@ -603,7 +609,10 @@ async function pushPresence(
               p_seconds: deltaSec,
               p_in_game: true,
             }).then(({ error: actErr }) => {
-              if (actErr) console.error('[activity] increment failed:', actErr.message);
+              if (actErr) {
+                console.error('[activity] increment failed:', actErr.message);
+                presenceLog.error('increment failed:', actErr.message);
+              }
             });
           }
         }
@@ -653,6 +662,7 @@ async function pushPresence(
     presenceStats.upsertFail++;
     presenceStats.lastError = `upsert: ${e}`;
     console.error('pushPresence failed', e);
+    presenceLog.error('pushPresence failed', e);
   }
 }
 
@@ -672,7 +682,9 @@ async function subscribeChannel(connectCode: string): Promise<boolean> {
   }
 
   console.log('[presence] Creating Realtime channel for', connectCode, `(gen=${gen})`);
+  presenceLog.info('Creating Realtime channel for', connectCode, `(gen=${gen})`);
   console.log('[presence] WebSocket available:', typeof globalThis.WebSocket !== 'undefined');
+  presenceLog.info('WebSocket available:', typeof globalThis.WebSocket !== 'undefined');
 
   presenceChannel = supabase.channel('presence:global', {
     config: {
@@ -694,8 +706,10 @@ async function subscribeChannel(connectCode: string): Promise<boolean> {
         reject(new Error('presence subscribe timeout (10s)'));
       }, 10_000);
       console.log('[presence] Calling channel.subscribe()...');
+      presenceLog.info('Calling channel.subscribe()...');
       presenceChannel!.subscribe((status, err) => {
         console.log('[presence] subscribe status:', status, err ? `error: ${err}` : '', `(gen=${gen}, current=${subscribeGeneration})`);
+        presenceLog.info('subscribe status:', status, err ? `error: ${err}` : '', `(gen=${gen}, current=${subscribeGeneration})`);
         if (gen !== subscribeGeneration) { clearTimeout(t); return; }
         if (status === 'SUBSCRIBED') {
           clearTimeout(t);
@@ -706,6 +720,7 @@ async function subscribeChannel(connectCode: string): Promise<boolean> {
           reject(new Error(`presence subscribe ${status}${err ? ': ' + err : ''}`));
         } else if (status === 'CLOSED' && subscribed) {
           console.warn('[presence] Channel closed after SUBSCRIBED — will retry');
+          presenceLog.warn('Channel closed after SUBSCRIBED — will retry');
           subscribed = false;
           presenceStats.realtimeConnected = false;
           presenceStats.lastError = 'channel closed unexpectedly';
@@ -716,13 +731,16 @@ async function subscribeChannel(connectCode: string): Promise<boolean> {
     channelRetryCount = 0;
     presenceStats.realtimeConnected = true;
     console.log('[presence] Realtime channel CONNECTED (gen=%d)', gen);
+    presenceLog.info('Realtime channel CONNECTED (gen=%d)', gen);
     return true;
   } catch (e: any) {
     if (gen !== subscribeGeneration) {
       console.log('[presence] Ignoring stale subscribe error (gen=%d, current=%d)', gen, subscribeGeneration);
+      presenceLog.info('Ignoring stale subscribe error (gen=%d, current=%d)', gen, subscribeGeneration);
       return false;
     }
     console.error('[presence] subscribeChannel failed:', e?.message ?? e);
+    presenceLog.error('subscribeChannel failed:', e?.message ?? e);
     presenceStats.subscribeFail++;
     presenceStats.lastError = `subscribe: ${e?.message ?? e}`;
     presenceStats.realtimeConnected = false;
@@ -743,9 +761,11 @@ function scheduleChannelRetry(): void {
   if (channelRetryTimer || channelRetryCount >= MAX_CHANNEL_RETRIES) {
     if (channelRetryCount >= MAX_CHANNEL_RETRIES && !periodicRetryTimer) {
       console.log('[presence] Retries exhausted — will re-attempt every 5 minutes');
+      presenceLog.info('Retries exhausted — will re-attempt every 5 minutes');
       periodicRetryTimer = setInterval(async () => {
         if (subscribed || !loopConnectCode) return;
         console.log('[presence] Periodic re-attempt of Realtime subscription...');
+        presenceLog.info('Periodic re-attempt of Realtime subscription...');
         channelRetryCount = 0;
         const ok = await subscribeChannel(loopConnectCode);
         if (ok && periodicRetryTimer) {
@@ -762,6 +782,7 @@ function scheduleChannelRetry(): void {
     if (subscribed || !loopConnectCode) return;
     channelRetryCount++;
     console.log(`[presence] Retrying channel subscription (${channelRetryCount}/${MAX_CHANNEL_RETRIES}) — next in ${delay * 2 / 1000}s...`);
+    presenceLog.info(`Retrying channel subscription (${channelRetryCount}/${MAX_CHANNEL_RETRIES}) — next in ${delay * 2 / 1000}s...`);
     const ok = await subscribeChannel(loopConnectCode);
     if (!ok) {
       scheduleChannelRetry();
@@ -784,15 +805,18 @@ export async function startPresenceLoop(
     loopDisplayName = displayName;
     loopUserId = userId;
     console.log('[presence] startPresenceLoop — subscribing channel...');
+    presenceLog.info('startPresenceLoop — subscribing channel...');
 
     if (process.platform === 'darwin' && !macDeviceTypeMap) {
       macDeviceTypeMap = await buildMacDeviceMap();
     }
     currentConnectionType = detectConnectionType();
     console.log('[presence] connection type:', currentConnectionType);
+    presenceLog.info('connection type:', currentConnectionType);
 
     const channelOk = await subscribeChannel(connectCode);
     console.log('[presence] startPresenceLoop — channelOk:', channelOk);
+    presenceLog.info('startPresenceLoop — channelOk:', channelOk);
     if (!channelOk) scheduleChannelRetry();
 
     const tick = async () => {
@@ -815,8 +839,13 @@ export async function startPresenceLoop(
             .in('status', ['online', 'in-game'])
             .lt('updated_at', cutoff)
             .then(({ error }) => {
-              if (error) console.warn('[presence] stale cleanup failed:', error.message);
-              else console.log('[presence] stale cleanup ran');
+              if (error) {
+                console.warn('[presence] stale cleanup failed:', error.message);
+                presenceLog.warn('stale cleanup failed:', error.message);
+              } else {
+                console.log('[presence] stale cleanup ran');
+                presenceLog.info('stale cleanup ran');
+              }
             });
         }
 
@@ -829,7 +858,10 @@ export async function startPresenceLoop(
         const launcherRunning = snapshotContains(snapshot, SLIPPI_LAUNCHER_PROCESS_NAMES);
         const dolphinRunning = snapshotContains(snapshot, DOLPHIN_PROCESS_NAMES);
         const procMs = performance.now() - t0;
-        if (procMs > 100) console.log(`[perf] process scan took ${procMs.toFixed(0)}ms`);
+        if (procMs > 100) {
+          console.log(`[perf] process scan took ${procMs.toFixed(0)}ms`);
+          presenceLog.info(`process scan took ${procMs.toFixed(0)}ms`);
+        }
 
         const next = resolvePresenceStatus(launcherRunning, dolphinRunning);
         if (next === 'in-game' && currentStatus !== 'in-game') {
@@ -843,6 +875,11 @@ export async function startPresenceLoop(
         if (next !== currentStatus) {
           console.log(
             `[presence] ${currentStatus} → ${next}` +
+            (opponent ? ` opponent=${opponent.code}` : '') +
+            (lastCharacterId != null ? ` myChar=${lastCharacterId}` : ''),
+          );
+          presenceLog.info(
+            `${currentStatus} → ${next}` +
             (opponent ? ` opponent=${opponent.code}` : '') +
             (lastCharacterId != null ? ` myChar=${lastCharacterId}` : ''),
           );
@@ -863,11 +900,15 @@ export async function startPresenceLoop(
           loopUserId,
         );
         const pushMs = performance.now() - t1;
-        if (pushMs > 200) console.log(`[perf] pushPresence took ${pushMs.toFixed(0)}ms`);
+        if (pushMs > 200) {
+          console.log(`[perf] pushPresence took ${pushMs.toFixed(0)}ms`);
+          presenceLog.info(`pushPresence took ${pushMs.toFixed(0)}ms`);
+        }
 
         if (!subscribed) scheduleChannelRetry();
       } catch (e) {
         console.error('presence tick failed', e);
+        presenceLog.error('presence tick failed', e);
       }
 
       const delay = (currentStatus === 'in-game' && throttleInGame)
@@ -879,6 +920,7 @@ export async function startPresenceLoop(
     void tick();
   } catch (e) {
     console.error('startPresenceLoop failed', e);
+    presenceLog.error('startPresenceLoop failed', e);
   }
 }
 
@@ -902,6 +944,7 @@ export async function stopPresenceLoop(): Promise<void> {
         await presenceChannel.untrack();
       } catch (e) {
         console.error('presence untrack failed', e);
+        presenceLog.error('presence untrack failed', e);
       }
       await presenceChannel.unsubscribe();
       subscribed = false;
@@ -920,6 +963,7 @@ export async function stopPresenceLoop(): Promise<void> {
     lastDbWriteTime = 0;
   } catch (e) {
     console.error('stopPresenceLoop failed', e);
+    presenceLog.error('stopPresenceLoop failed', e);
   }
 }
 
@@ -974,7 +1018,7 @@ export async function pushOfflineAndStop(): Promise<void> {
       subscribed = false;
       presenceChannel = null;
     }
-  } catch (e) { console.error('pushOfflineAndStop failed', e); }
+  } catch (e) { console.error('pushOfflineAndStop failed', e); presenceLog.error('pushOfflineAndStop failed', e); }
 }
 
 export function updatePresenceReplayDir(_dir: string): void {

--- a/apps/agent/src/renderer/components/Navigation.tsx
+++ b/apps/agent/src/renderer/components/Navigation.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { isGameActive } from '../App';
+import { version } from '../../../package.json';
 
 const baseLinks = [
   { to: '/', label: 'Friends', icon: '♟' },
@@ -119,7 +120,7 @@ export function Navigation() {
             {copied ? 'Copied!' : 'Share with a Friend!'}
           </button>
         </div>
-        <div className="px-5 py-2 text-[10px] text-gray-600">v1.0.39</div>
+        <div className="px-5 py-2 text-[10px] text-gray-600">v{version}</div>
       </aside>
       <main className="flex-1 overflow-y-auto">
         <div className="h-[52px] shrink-0 drag relative">

--- a/apps/agent/src/renderer/components/PlayerCard.tsx
+++ b/apps/agent/src/renderer/components/PlayerCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { ConnectionTypeIcon } from './ConnectionTypeIcon';
 import { OnlineIndicator } from './OnlineIndicator';
 import { RankBadge } from './RankBadge';
@@ -17,6 +17,7 @@ function DiscordIcon({ className }: { className?: string }) {
 
 interface PlayerCardProps {
   player: {
+    userId?: string;
     connectCode: string;
     displayName?: string;
     discordUsername?: string;
@@ -97,9 +98,53 @@ function playerCardAreEqual(prev: PlayerCardProps, next: PlayerCardProps): boole
 export const PlayerCard = memo(function PlayerCard({ player, showStatus = true, expandable = true, onClick, onBlock, onRemove, onInvite, inviteDisabled, inviteState, nudgeOptions, onNudge, nudgeState, onAdd, addDisabled, addState, removeLabel, onUnsend, rankOverride, patreonPublicSupporter }: PlayerCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [nudgePickerOpen, setNudgePickerOpen] = useState(false);
+  const [mutualOpen, setMutualOpen] = useState(false);
+  const [mutualFriends, setMutualFriends] = useState<{ userId: string; connectCode: string; displayName: string | null; avatarUrl: string | null; rating: number | null; topCharacters: { characterId: number; gameCount: number }[]; region: string | null }[] | null>(null);
+  const [mutualLoading, setMutualLoading] = useState(false);
+  const [mutualShowAll, setMutualShowAll] = useState(false);
+  const mutualRef = useRef<HTMLDivElement>(null);
+  const mutualBtnRef = useRef<HTMLButtonElement>(null);
+  const [mutualPos, setMutualPos] = useState<{ top: number; left: number } | null>(null);
   const hasAvatar = !!player.avatarUrl;
 
-  function handleClick() {
+  useEffect(() => {
+    if (!mutualOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (mutualRef.current && !mutualRef.current.contains(e.target as Node) &&
+          mutualBtnRef.current && !mutualBtnRef.current.contains(e.target as Node)) {
+        setMutualOpen(false);
+        setMutualShowAll(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [mutualOpen]);
+
+  const handleMutualClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!player.userId) return;
+    if (mutualOpen) {
+      setMutualOpen(false);
+      setMutualShowAll(false);
+      return;
+    }
+    if (mutualBtnRef.current) {
+      const rect = mutualBtnRef.current.getBoundingClientRect();
+      setMutualPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setMutualOpen(true);
+    if (mutualFriends === null) {
+      setMutualLoading(true);
+      window.api.getMutualFriendsFor(player.userId).then((friends: any[]) => {
+        setMutualFriends(friends);
+        setMutualLoading(false);
+      }).catch(() => { setMutualLoading(false); });
+    }
+  }, [player.userId, mutualOpen, mutualFriends]);
+
+
+  function handleClick(e: React.MouseEvent) {
+    if (mutualBtnRef.current?.contains(e.target as Node)) return;
     if (expandable) {
       setExpanded((prev) => !prev);
     }
@@ -172,9 +217,80 @@ export const PlayerCard = memo(function PlayerCard({ player, showStatus = true, 
               <span className="text-[10px] text-gray-600 truncate">{player.region}</span>
             )}
             {player.mutualFriendCount != null && player.mutualFriendCount > 0 && (
-              <span className="text-[10px] text-[#21BA45]/70 shrink-0" title="Accepted friends you share">
-                {player.mutualFriendCount} mutual friend{player.mutualFriendCount === 1 ? '' : 's'}
-              </span>
+              player.userId ? (
+                <div className="shrink-0">
+                  <button
+                    ref={mutualBtnRef}
+                    onClick={handleMutualClick}
+                    className={`text-[10px] transition-colors ${mutualOpen ? 'text-[#21BA45]' : 'text-[#21BA45]/70 hover:text-[#21BA45]'}`}
+                    title="Click to see mutual friends"
+                  >
+                    {player.mutualFriendCount} mutual friend{player.mutualFriendCount === 1 ? '' : 's'}
+                    <span className="ml-0.5 text-[8px]">{mutualOpen ? '▲' : '▼'}</span>
+                  </button>
+                  {mutualOpen && mutualPos && (
+                    <div
+                      ref={mutualRef}
+                      className="fixed z-[9999] rounded-lg border border-[#2a2a2a] bg-[#141414] min-w-[240px] max-w-[300px]"
+                      style={{ top: mutualPos.top, left: mutualPos.left, boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)' }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="px-3 py-2 border-b border-[#2a2a2a]">
+                        <span className="text-[9px] text-gray-500 uppercase tracking-wider">Mutual friends</span>
+                      </div>
+                      {mutualLoading ? (
+                        <div className="flex items-center gap-2 px-3 py-3 text-[10px] text-gray-500 animate-pulse">
+                          <span className="h-1.5 w-1.5 rounded-full bg-[#21BA45]/40" /> Loading...
+                        </div>
+                      ) : mutualFriends && mutualFriends.length > 0 ? (
+                        <>
+                          <div className="py-1">
+                            {(mutualShowAll ? mutualFriends : mutualFriends.slice(0, 5)).map((mf) => (
+                                <div key={mf.userId} className="flex items-center gap-2 px-3 py-1.5 hover:bg-white/5">
+                                  {mf.avatarUrl ? (
+                                    <img src={mf.avatarUrl} alt="" className="w-5 h-5 rounded-full object-cover shrink-0 border border-[#2a2a2a]" />
+                                  ) : mf.topCharacters?.[0] ? (
+                                    <CharacterIcon characterId={mf.topCharacters[0].characterId} size="sm" />
+                                  ) : (
+                                    <div className="w-5 h-5 rounded-full bg-[#1a1a1a] border border-[#2a2a2a] shrink-0" />
+                                  )}
+                                  <span className="font-mono text-[11px] text-white">{mf.connectCode}</span>
+                                  {mf.displayName && <span className="text-[10px] text-gray-500 truncate flex-1 min-w-0">{mf.displayName}</span>}
+                                  {mf.rating != null && (
+                                    <span className="text-[10px] text-gray-500 shrink-0">{Math.round(mf.rating)}</span>
+                                  )}
+                                  {mf.region && <span className="text-[9px] text-gray-600 shrink-0">{mf.region}</span>}
+                                </div>
+                            ))}
+                          </div>
+                          {mutualFriends.length > 5 && !mutualShowAll && (
+                            <button
+                              onClick={() => setMutualShowAll(true)}
+                              className="w-full border-t border-[#2a2a2a] px-3 py-2 text-[10px] text-[#21BA45]/70 hover:text-[#21BA45] hover:bg-white/5 transition-colors text-left"
+                            >
+                              and {mutualFriends.length - 5} more...
+                            </button>
+                          )}
+                          {mutualShowAll && mutualFriends.length > 5 && (
+                            <button
+                              onClick={() => setMutualShowAll(false)}
+                              className="w-full border-t border-[#2a2a2a] px-3 py-1.5 text-[10px] text-gray-500 hover:text-gray-300 hover:bg-white/5 transition-colors text-left"
+                            >
+                              Show less
+                            </button>
+                          )}
+                        </>
+                      ) : (
+                        <div className="px-3 py-3 text-[10px] text-gray-500">No mutual friends found</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <span className="text-[10px] text-[#21BA45]/70 shrink-0" title="Accepted friends you share">
+                  {player.mutualFriendCount} mutual friend{player.mutualFriendCount === 1 ? '' : 's'}
+                </span>
+              )
             )}
           </div>
           {(player.statusPreset || (isLfg && !player.statusPreset)) && (

--- a/apps/agent/src/renderer/lib/friend-request-tags.ts
+++ b/apps/agent/src/renderer/lib/friend-request-tags.ts
@@ -1,0 +1,8 @@
+export const FRIEND_REQUEST_TAGS = [
+  'Looking for MU practice',
+  'GGs from unranked',
+  'Same region',
+  'Just saying hi',
+  'Similar skill level',
+  'We have mutual friends',
+] as const;

--- a/apps/agent/src/renderer/pages/Discover.tsx
+++ b/apps/agent/src/renderer/pages/Discover.tsx
@@ -5,6 +5,7 @@ import { CharacterIcon } from '../components/CharacterIcon';
 import { ConnectionTypeIcon } from '../components/ConnectionTypeIcon';
 import { RankBadge } from '../components/RankBadge';
 import { CHARACTER_MAP, getCharacterImagePath, getCharacterShortName } from '../lib/characters';
+import { FRIEND_REQUEST_TAGS } from '../lib/friend-request-tags';
 
 interface DiscoverPlayer {
   userId: string;
@@ -116,10 +117,12 @@ const TOP_CHARACTERS = [2, 20, 9, 19, 15, 12, 0];
 const TOP_SET = new Set(TOP_CHARACTERS);
 const REST_CHARACTERS = ALL_CHARACTER_IDS.filter((id) => !TOP_SET.has(id));
 
-function CharacterFilter({ selected, onToggle, onClear }: {
+function CharacterFilter({ selected, onToggle, onClear, hasMutualFriends, onHasMutualFriendsToggle }: {
   selected: Set<number>;
   onToggle: (id: number) => void;
   onClear: () => void;
+  hasMutualFriends: boolean;
+  onHasMutualFriendsToggle: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -175,6 +178,19 @@ function CharacterFilter({ selected, onToggle, onClear }: {
           `}
         >
           <span className="text-xs font-medium">{expanded ? 'Less' : 'More'}</span>
+        </button>
+        <div className="h-10 w-px bg-[#333] mx-2" />
+        <button
+          onClick={onHasMutualFriendsToggle}
+          className={`
+            relative h-10 px-3 rounded-lg border transition-all flex items-center justify-center
+            ${hasMutualFriends
+              ? 'border-[#21BA45]/60 bg-[#21BA45]/15 ring-1 ring-[#21BA45]/30 text-[#21BA45]'
+              : 'border-[#2a2a2a] bg-[#141414] text-gray-500 opacity-60 hover:opacity-90 hover:border-[#3a3a3a]'
+            }
+          `}
+        >
+          <span className="text-xs font-medium">Has Mutual Friends</span>
         </button>
       </div>
       {expanded && (
@@ -232,6 +248,7 @@ export function Discover() {
   const [eloFilter, setEloFilter] = useState<Set<number>>(new Set());
   const [search, setSearch] = useState('');
   const [patreonCodes, setPatreonCodes] = useState<Set<string>>(new Set());
+  const [hasMutualFriends, setMutualFilter] = useState(false);
   const charFilterRef = useRef(charFilter);
   charFilterRef.current = charFilter;
   const eloFilterRef = useRef(eloFilter);
@@ -383,6 +400,7 @@ export function Discover() {
     loadSentInvites();
     loadPlayInvites();
     loadPatreonCodes();
+
     window.api.getIdentity().then((id) => { if (id) setMyCode(id.connectCode); });
     const interval = setInterval(() => {
       if (!document.hidden && !isGameActive()) {
@@ -390,6 +408,7 @@ export function Discover() {
         loadSentInvites();
         loadPlayInvites();
         loadPatreonCodes();
+
       }
     }, 30_000);
     const onVisible = () => {
@@ -398,6 +417,7 @@ export function Discover() {
         loadSentInvites();
         loadPlayInvites();
         loadPatreonCodes();
+
       }
     };
     document.addEventListener('visibilitychange', onVisible);
@@ -503,7 +523,7 @@ export function Discover() {
 
   const filtered = useMemo(() => {
     const STATUS_ORDER: Record<string, number> = { online: 1, 'in-game': 2, idle: 3, offline: 4 };
-    const list = search
+    let list = search
       ? players.filter((p) => {
           const q = search.toLowerCase();
           return (
@@ -513,6 +533,9 @@ export function Discover() {
           );
         })
       : players;
+    if (hasMutualFriends) {
+      list = list.filter((p) => (p.mutualFriendCount ?? 0) > 0);
+    }
     return [...list].sort((a, b) => {
       const aHistory = a.lastPlayedAt ? 1 : 0;
       const bHistory = b.lastPlayedAt ? 1 : 0;
@@ -527,7 +550,7 @@ export function Discover() {
       const bOrd = STATUS_ORDER[b.status] ?? 5;
       return aOrd - bOrd;
     });
-  }, [players, search]);
+  }, [players, search, hasMutualFriends]);
 
   return (
     <div className="space-y-6 max-w-4xl">
@@ -550,6 +573,8 @@ export function Discover() {
         selected={charFilter}
         onToggle={toggleChar}
         onClear={clearFilter}
+        hasMutualFriends={hasMutualFriends}
+        onHasMutualFriendsToggle={() => { setMutualFilter((v) => !v); setVisibleCount(15); }}
       />
 
       <EloFilter
@@ -745,7 +770,7 @@ export function Discover() {
           </>
         )}
 
-        {!loading && filtered.length === 0 && !search && charFilter.size === 0 && eloFilter.size === 0 && (
+        {!loading && filtered.length === 0 && !search && charFilter.size === 0 && eloFilter.size === 0 && !hasMutualFriends && (
           <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-12 text-center">
             <p className="text-gray-500 text-sm">
               No players online right now. Check back later!
@@ -753,10 +778,11 @@ export function Discover() {
           </div>
         )}
 
-        {!loading && filtered.length === 0 && (search || charFilter.size > 0 || eloFilter.size > 0) && (
+        {!loading && filtered.length === 0 && (search || charFilter.size > 0 || eloFilter.size > 0 || hasMutualFriends) && (
           <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-12 text-center">
             <p className="text-gray-500 text-sm">
               {search ? 'No players match your search.'
+                : hasMutualFriends ? 'No online players with mutual friends right now.'
                 : eloFilter.size > 0 && charFilter.size > 0 ? 'No players match the selected rank and characters.'
                 : eloFilter.size > 0 ? 'No players match the selected rank.'
                 : 'No players match the selected characters.'}
@@ -778,6 +804,7 @@ export function Discover() {
               )}
               <PlayerCard
                 player={{
+                  userId: p.userId,
                   connectCode: p.connectCode,
                   displayName: p.displayName,
                   discordUsername: p.discordUsername ?? undefined,
@@ -836,7 +863,7 @@ export function Discover() {
             When adding a player, it often helps to let them know a bit more info on what you're looking for! Notes are optional.
             </p>
             <div className="flex flex-wrap gap-2 mt-4 justify-center">
-              {['Looking for MU practice', 'GGs from unranked', 'Same region', 'Just saying hi', 'Similar skill level'].map((tag) => (
+              {FRIEND_REQUEST_TAGS.map((tag) => (
                 <button
                   key={tag}
                   onClick={() => setAddNote(addNote === tag ? null : tag)}

--- a/apps/agent/src/renderer/pages/Friends.tsx
+++ b/apps/agent/src/renderer/pages/Friends.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { isGameActive } from '../App';
 import { ConnectionTypeIcon } from '../components/ConnectionTypeIcon';
 import { OnlineIndicator } from '../components/OnlineIndicator';
@@ -6,8 +6,10 @@ import { PlayerCard } from '../components/PlayerCard';
 import { RankBadge } from '../components/RankBadge';
 import { CharacterIcon } from '../components/CharacterIcon';
 import { CHARACTER_MAP, getCharacterImagePath, getCharacterShortName } from '../lib/characters';
+import { FRIEND_REQUEST_TAGS } from '../lib/friend-request-tags';
 import { getRankTier } from '../lib/ranks';
 import { friendsSelfStatusShell, PatronBadge } from '../lib/patronCardStyle';
+
 
 function DiscordIcon({ className }: { className?: string }) {
   return (
@@ -62,6 +64,7 @@ function SkeletonCard() {
 }
 
 export function Friends() {
+
   const [friends, setFriends] = useState<Friend[]>([]);
   const [incoming, setIncoming] = useState<IncomingRequest[]>([]);
   const [onlineMap, setOnlineMap] = useState<Record<string, { status: string; opponentCode?: string; currentCharacter?: number | null; playingSince?: string; gameMode?: string | null; lookingToPlay?: boolean; statusPreset?: string | null; lfgCharacters?: number[]; lfgRanks?: string[]; connectionType?: 'wifi' | 'ethernet' | null }>>({});
@@ -1156,7 +1159,7 @@ export function Friends() {
       )}
 
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-display font-bold">Friends</h1>
+        <h1 className="px-3 py-1.5 text-lg font-display font-bold text-white">Friends</h1>
         {!initialLoading && (
           <div className="flex items-center gap-2">
             {(['all', 'online', 'in-game', 'offline'] as const).map((f) => (
@@ -1188,6 +1191,7 @@ export function Friends() {
         )}
       </div>
 
+      {(<>
       <div className="flex gap-2">
         <input
           type="text"
@@ -1418,7 +1422,7 @@ export function Friends() {
                 When adding a player, it often helps to let them know a bit more info on what you're looking for! Notes are optional.
               </p>
               <div className="flex flex-wrap gap-2 mt-4 justify-center">
-                {['Looking for MU practice', 'GGs from unranked', 'Same region', 'Just saying hi', 'Similar skill level'].map((tag) => (
+                {FRIEND_REQUEST_TAGS.map((tag) => (
                   <button
                     key={tag}
                     onClick={() => setAddNote(addNote === tag ? null : tag)}
@@ -1543,6 +1547,8 @@ export function Friends() {
           </button>
         )}
       </div>
+      </>)}
+
     </div>
   );
 }

--- a/apps/agent/src/renderer/pages/Settings.tsx
+++ b/apps/agent/src/renderer/pages/Settings.tsx
@@ -526,6 +526,56 @@ export function Settings() {
         </div>
       )}
 
+      {show('troubleshoot', 'debug', 'logs', 'export', 'diagnostics') && (
+      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+        <div className="p-5 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-300">Troubleshooting</p>
+            <p className="text-xs text-gray-500 mt-0.5">Export application logs and metadata for debugging</p>
+          </div>
+          {import.meta.env.DEV ? (
+          <div className="inline-flex rounded-lg border border-[#2a2a2a] overflow-hidden">
+            <button
+              className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors"
+              onClick={() => { window.api.openLogsDirectory(); }}
+            >
+              Open Logs Directory
+            </button>
+            <button
+              className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors border-l border-[#2a2a2a] flex items-center gap-1.5"
+              onClick={async () => {
+                try {
+                  const filePath = await window.api.exportDiagnostics();
+                  if (filePath) flash();
+                } catch {}
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
+              </svg>
+              Export
+            </button>
+          </div>
+          ) : (
+          <button
+            className="px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#2a2a2a] text-sm text-gray-300 hover:bg-[#222] transition-colors flex items-center gap-1.5"
+            onClick={async () => {
+              try {
+                const filePath = await window.api.exportDiagnostics();
+                if (filePath) flash();
+              } catch {}
+            }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+              <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
+            </svg>
+            Export
+          </button>
+          )}
+        </div>
+      </div>
+      )}
+
       {show('account', 'log out', 'logout', 'update', 'version') && (
       <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
         <h3 className="text-sm font-medium text-gray-300 mb-4">Account</h3>

--- a/apps/agent/src/renderer/pages/Settings.tsx
+++ b/apps/agent/src/renderer/pages/Settings.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
-import { isGameActive } from '../App';
-import { version } from '../../../package.json';
+import { useEffect, useRef, useState } from "react";
+import { isGameActive } from "../App";
+import { version } from "../../../package.json";
 
 interface SettingsState {
   replayDir: string;
@@ -35,12 +35,12 @@ interface PresenceStats {
   realtimeConnected: boolean;
 }
 
-const DEBUG_CONNECT_CODES = ['SMOK#1', 'BF#0'];
+const DEBUG_CONNECT_CODES = ["SMOK#1", "BF#0"];
 export function Settings() {
   const [pStats, setPStats] = useState<PresenceStats | null>(null);
   const [myCode, setMyCode] = useState<string | null>(null);
   const [settings, setSettings] = useState<SettingsState>({
-    replayDir: '',
+    replayDir: "",
     autoLaunch: false,
     closeToTray: false,
     showNotifications: true,
@@ -54,50 +54,97 @@ export function Settings() {
     disableChat: false,
   });
   const [metrics, setMetrics] = useState<AppMetric[] | null>(null);
-  const [privacy, setPrivacy] = useState({ hideRegion: false, hideDiscordUnlessFriends: false, hideAvatar: false, hideConnectionType: false, hideOnlineStatus: false, disableFriendRequests: false, chosenRegion: null as string | null });
+  const [privacy, setPrivacy] = useState({
+    hideRegion: false,
+    hideDiscordUnlessFriends: false,
+    hideAvatar: false,
+    hideConnectionType: false,
+    hideOnlineStatus: false,
+    disableFriendRequests: false,
+    hideMutualFriends: false,
+    chosenRegion: null as string | null,
+  });
   const [saved, setSaved] = useState(false);
   const [updateMsg, setUpdateMsg] = useState<string | null>(null);
   const [slippiDir, setSlippiDir] = useState<string | null>(null);
-  const [blockedUsers, setBlockedUsers] = useState<{ connectCode: string; displayName: string | null; avatarUrl: string | null; blockedAt: string }[]>([]);
+  const [blockedUsers, setBlockedUsers] = useState<
+    {
+      connectCode: string;
+      displayName: string | null;
+      avatarUrl: string | null;
+      blockedAt: string;
+    }[]
+  >([]);
   const [unblocking, setUnblocking] = useState<string | null>(null);
 
   useEffect(() => {
     window.api.getSettings().then((s) => {
       setSettings({
-        replayDir: s.replayDir || '',
+        replayDir: s.replayDir || "",
         autoLaunch: s.autoLaunch || false,
         closeToTray: !!s.closeToTray,
         showNotifications: s.showNotifications !== false,
         notifyFriendOnline: s.notifyFriendOnline !== false,
         notifyPlayInvite: s.notifyPlayInvite !== false,
         notificationSound: s.notificationSound !== false,
-        notificationVolume: typeof s.notificationVolume === 'number' ? s.notificationVolume : 0.35,
+        notificationVolume:
+          typeof s.notificationVolume === "number"
+            ? s.notificationVolume
+            : 0.35,
         reduceBackgroundActivity: s.reduceBackgroundActivity !== false,
         disableNudges: !!s.disableNudges,
         disableStatuses: !!s.disableStatuses,
         disableChat: !!s.disableChat,
       });
     });
-    window.api.getPrivacy().then(setPrivacy).catch(() => {});
-    window.api.getSlippiDir().then(setSlippiDir).catch(() => {});
+    window.api
+      .getPrivacy()
+      .then(setPrivacy)
+      .catch(() => {});
+    window.api
+      .getSlippiDir()
+      .then(setSlippiDir)
+      .catch(() => {});
     loadBlockedUsers();
     window.api.getIdentity().then((id) => {
       if (id?.connectCode) setMyCode(id.connectCode);
     });
-    const fetchStats = () => (window.api as any).getPresenceStats?.().then((s: PresenceStats) => setPStats(s)).catch(() => {});
+    const fetchStats = () =>
+      (window.api as any)
+        .getPresenceStats?.()
+        .then((s: PresenceStats) => setPStats(s))
+        .catch(() => {});
     fetchStats();
-    const statsInterval = setInterval(() => { if (!document.hidden && !isGameActive()) fetchStats(); }, 30_000);
-    const fetchMetrics = () => window.api.getAppMetrics().then(setMetrics).catch(() => {});
+    const statsInterval = setInterval(() => {
+      if (!document.hidden && !isGameActive()) fetchStats();
+    }, 30_000);
+    const fetchMetrics = () =>
+      window.api
+        .getAppMetrics()
+        .then(setMetrics)
+        .catch(() => {});
     fetchMetrics();
-    const metricsInterval = setInterval(() => { if (!document.hidden && !isGameActive()) fetchMetrics(); }, 30_000);
+    const metricsInterval = setInterval(() => {
+      if (!document.hidden && !isGameActive()) fetchMetrics();
+    }, 30_000);
     const unsub = window.api.onUpdateStatus((s: any) => {
-      if (s.state === 'not-available') setUpdateMsg('Up to date');
-      else if (s.state === 'available') setUpdateMsg(null);
-      else if (s.state === 'error') setUpdateMsg(null);
+      if (s.state === "not-available") setUpdateMsg("Up to date");
+      else if (s.state === "available") setUpdateMsg(null);
+      else if (s.state === "error") setUpdateMsg(null);
     });
-    const onVisible = () => { if (!document.hidden) { fetchStats(); fetchMetrics(); } };
-    document.addEventListener('visibilitychange', onVisible);
-    return () => { unsub(); clearInterval(statsInterval); clearInterval(metricsInterval); document.removeEventListener('visibilitychange', onVisible); };
+    const onVisible = () => {
+      if (!document.hidden) {
+        fetchStats();
+        fetchMetrics();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      unsub();
+      clearInterval(statsInterval);
+      clearInterval(metricsInterval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
   async function handleBrowse() {
@@ -109,7 +156,7 @@ export function Settings() {
     }
   }
 
-  async function toggle(key: keyof Omit<SettingsState, 'replayDir'>) {
+  async function toggle(key: keyof Omit<SettingsState, "replayDir">) {
     const next = !settings[key];
     setSettings((s) => ({ ...s, [key]: next }));
     await window.api.updateSettings({ [key]: next });
@@ -148,16 +195,19 @@ export function Settings() {
   }
 
   const notifsEnabled = settings.showNotifications;
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState("");
   const sq = searchQuery.toLowerCase();
-  const show = (...terms: string[]) => !sq || terms.some(t => t.toLowerCase().includes(sq));
+  const show = (...terms: string[]) =>
+    !sq || terms.some((t) => t.toLowerCase().includes(sq));
 
   return (
     <div className="space-y-6 max-w-4xl">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-display font-bold">Settings</h1>
         {saved && (
-          <span className="text-xs text-[#21BA45] font-medium animate-pulse">Saved</span>
+          <span className="text-xs text-[#21BA45] font-medium animate-pulse">
+            Saved
+          </span>
         )}
       </div>
 
@@ -169,348 +219,520 @@ export function Settings() {
         className="w-full rounded-lg border border-[#2a2a2a] bg-[#0a0a0a] px-4 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#21BA45]/50"
       />
 
-      {show('replay', 'directory', 'display region', 'region', 'launch', 'login', 'close', 'tray', 'slippi', 'launcher', 'install', 'path', 'custom') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        {show('replay', 'directory') && (
-        <div className="p-5">
-          <label className="text-sm font-medium text-gray-300">Replay Directory</label>
-          <div className="flex gap-2 mt-2">
-            <input
-              type="text"
-              value={settings.replayDir}
-              readOnly
-              className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#0a0a0a] px-4 py-2.5 text-sm font-mono text-white"
-            />
-            <button
-              onClick={handleBrowse}
-              className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
-            >
-              Change
-            </button>
-          </div>
-        </div>
-        )}
-
-        {show('slippi', 'launcher', 'install', 'path', 'custom') && (
-        <div className="p-5">
-          <label className="text-sm font-medium text-gray-300">Slippi Launcher Path</label>
-          <p className="text-xs text-gray-500 mt-0.5 mb-2">Override if Slippi Launcher data is on a different drive</p>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={slippiDir || ''}
-              readOnly
-              placeholder="Default (auto-detect)"
-              className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#0a0a0a] px-4 py-2.5 text-sm font-mono text-white placeholder-gray-600"
-            />
-            <button
-              onClick={async () => {
-                const dir = await window.api.browseSlippiDir();
-                if (dir) {
-                  await window.api.setSlippiDir(dir);
-                  setSlippiDir(dir);
-                  flash();
-                }
-              }}
-              className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
-            >
-              Change
-            </button>
-            {slippiDir && (
-              <button
-                onClick={async () => {
-                  await window.api.setSlippiDir(null);
-                  setSlippiDir(null);
-                  flash();
-                }}
-                className="shrink-0 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20"
-              >
-                Reset
-              </button>
-            )}
-          </div>
-        </div>
-        )}
-
-        {!privacy.hideRegion && show('display region', 'region', 'override', 'auto-detect', 'profile') && (
-          <div className="flex items-center justify-between px-5 py-3">
-            <div>
-              <p className="text-sm font-medium text-gray-300">Display Region</p>
-              <p className="text-xs text-gray-500">Override the auto-detected region shown on your profile</p>
+      {show(
+        "replay",
+        "directory",
+        "display region",
+        "region",
+        "launch",
+        "login",
+        "close",
+        "tray",
+        "slippi",
+        "launcher",
+        "install",
+        "path",
+        "custom",
+      ) && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+          {show("replay", "directory") && (
+            <div className="p-5">
+              <label className="text-sm font-medium text-gray-300">
+                Replay Directory
+              </label>
+              <div className="flex gap-2 mt-2">
+                <input
+                  type="text"
+                  value={settings.replayDir}
+                  readOnly
+                  className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#0a0a0a] px-4 py-2.5 text-sm font-mono text-white"
+                />
+                <button
+                  onClick={handleBrowse}
+                  className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
+                >
+                  Change
+                </button>
+              </div>
             </div>
-            <select
-              className="bg-[#21BA45]/10 border border-[#21BA45]/40 rounded-lg px-3 py-1.5 text-sm text-[#21BA45] font-medium focus:outline-none focus:border-[#21BA45]/70 min-w-[180px] cursor-pointer"
-              value={privacy.chosenRegion || ''}
-              onChange={async (e) => {
-                const val = e.target.value || null;
-                setPrivacy((s) => ({ ...s, chosenRegion: val }));
-                await window.api.setRegion(val);
-                flash();
-              }}
-            >
-              <option value="">Auto-detect</option>
-              <optgroup label="United States">
-                {['MDVA','Tristate','New England','Florida','NorCal','Central Cal','SoCal','Pacific Northwest','Midwest','Southwest','South'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Canada">
-                {['British Columbia','Alberta','Saskatchewan','Manitoba','Ontario','Quebec','Atlantic Canada (NB/NS/PEI/NFLD)'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Latin America">
-                {['Mexico'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Europe">
-                {['UK','Ireland','Germany','Sweden','France','Netherlands','Norway','Denmark','Finland','Spain','Portugal','Italy','Poland','Austria','Switzerland','EU'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Oceania">
-                {['NSW','VIC','QLD','WA','SA','TAS','ACT','NT','New Zealand'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Asia">
-                {['Japan','South Korea','Philippines','Southeast Asia'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-              <optgroup label="Other">
-                {['South America','Middle East','Africa'].map((s) => <option key={s} value={s}>{s}</option>)}
-              </optgroup>
-            </select>
-          </div>
-        )}
-        {show('launch', 'login', 'start', 'auto') && (
-        <ToggleRow
-          label="Launch at Login"
-          description="Start friendlies automatically when you log in"
-          checked={settings.autoLaunch}
-          onChange={() => toggle('autoLaunch')}
-        />
-        )}
-        {show('close', 'tray', 'minimize', 'quit') && (
-        <ToggleRow
-          label="Close to Tray"
-          description="Minimize to the system tray instead of quitting when you close the window"
-          checked={settings.closeToTray}
-          onChange={() => toggle('closeToTray')}
-        />
-        )}
-      </div>
-      )}
+          )}
 
-      {show('notification', 'friend online', 'play invite', 'sound', 'volume', 'test') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        {show('notification', 'desktop') && (
-        <ToggleRow
-          label="Notifications"
-          description="Enable desktop notifications"
-          checked={settings.showNotifications}
-          onChange={() => toggle('showNotifications')}
-        />
-        )}
+          {show("slippi", "launcher", "install", "path", "custom") && (
+            <div className="p-5">
+              <label className="text-sm font-medium text-gray-300">
+                Slippi Launcher Path
+              </label>
+              <p className="text-xs text-gray-500 mt-0.5 mb-2">
+                Override if Slippi Launcher data is on a different drive
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={slippiDir || ""}
+                  readOnly
+                  placeholder="Default (auto-detect)"
+                  className="flex-1 rounded-lg border border-[#2a2a2a] bg-[#0a0a0a] px-4 py-2.5 text-sm font-mono text-white placeholder-gray-600"
+                />
+                <button
+                  onClick={async () => {
+                    const dir = await window.api.browseSlippiDir();
+                    if (dir) {
+                      await window.api.setSlippiDir(dir);
+                      setSlippiDir(dir);
+                      flash();
+                    }
+                  }}
+                  className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
+                >
+                  Change
+                </button>
+                {slippiDir && (
+                  <button
+                    onClick={async () => {
+                      await window.api.setSlippiDir(null);
+                      setSlippiDir(null);
+                      flash();
+                    }}
+                    className="shrink-0 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20"
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
 
-        {show('friend online', 'notify', 'notification') && (
-        <ToggleRow
-          label="Friend Online"
-          description="Notify when a friend comes online or enters a game"
-          checked={notifsEnabled && settings.notifyFriendOnline}
-          onChange={() => toggle('notifyFriendOnline')}
-          disabled={!notifsEnabled}
-          indent
-        />
-        )}
-
-        {show('play invite', 'notify', 'notification') && (
-        <ToggleRow
-          label="Play Invites"
-          description="Notify when a friend invites you to play"
-          checked={notifsEnabled && settings.notifyPlayInvite}
-          onChange={() => toggle('notifyPlayInvite')}
-          disabled={!notifsEnabled}
-          indent
-        />
-        )}
-
-        {show('notification sound', 'sound effect') && (
-        <ToggleRow
-          label="Notification Sound"
-          description="Play a sound effect with notifications"
-          checked={notifsEnabled && settings.notificationSound}
-          onChange={() => toggle('notificationSound')}
-          disabled={!notifsEnabled}
-          indent
-        />
-        )}
-
-        {show('volume', 'sound') && (
-        <div className={`flex items-center justify-between p-5 pl-10 ${!notifsEnabled || !settings.notificationSound ? 'opacity-40 pointer-events-none' : ''}`}>
-          <div>
-            <p className="text-sm font-medium text-gray-300">Volume</p>
-            <p className="text-xs text-gray-500 mt-0.5">Adjust notification sound volume</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <input
-              type="range"
-              min={0}
-              max={0.35}
-              step={0.01}
-              value={settings.notificationVolume}
-              onChange={(e) => {
-                const vol = parseFloat(e.target.value);
-                setSettings((s) => ({ ...s, notificationVolume: vol }));
-                window.api.updateSettings({ notificationVolume: vol });
-              }}
-              className="w-28 accent-[#21BA45] h-1.5 bg-[#333] rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-md"
+          {!privacy.hideRegion &&
+            show(
+              "display region",
+              "region",
+              "override",
+              "auto-detect",
+              "profile",
+            ) && (
+              <div className="flex items-center justify-between px-5 py-3">
+                <div>
+                  <p className="text-sm font-medium text-gray-300">
+                    Display Region
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Override the auto-detected region shown on your profile
+                  </p>
+                </div>
+                <select
+                  className="bg-[#21BA45]/10 border border-[#21BA45]/40 rounded-lg px-3 py-1.5 text-sm text-[#21BA45] font-medium focus:outline-none focus:border-[#21BA45]/70 min-w-[180px] cursor-pointer"
+                  value={privacy.chosenRegion || ""}
+                  onChange={async (e) => {
+                    const val = e.target.value || null;
+                    setPrivacy((s) => ({ ...s, chosenRegion: val }));
+                    await window.api.setRegion(val);
+                    flash();
+                  }}
+                >
+                  <option value="">Auto-detect</option>
+                  <optgroup label="United States">
+                    {[
+                      "MDVA",
+                      "Tristate",
+                      "New England",
+                      "Florida",
+                      "NorCal",
+                      "Central Cal",
+                      "SoCal",
+                      "Pacific Northwest",
+                      "Midwest",
+                      "Southwest",
+                      "South",
+                    ].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Canada">
+                    {[
+                      "British Columbia",
+                      "Alberta",
+                      "Saskatchewan",
+                      "Manitoba",
+                      "Ontario",
+                      "Quebec",
+                      "Atlantic Canada (NB/NS/PEI/NFLD)",
+                    ].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Latin America">
+                    {["Mexico"].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Europe">
+                    {[
+                      "UK",
+                      "Ireland",
+                      "Germany",
+                      "Sweden",
+                      "France",
+                      "Netherlands",
+                      "Norway",
+                      "Denmark",
+                      "Finland",
+                      "Spain",
+                      "Portugal",
+                      "Italy",
+                      "Poland",
+                      "Austria",
+                      "Switzerland",
+                      "EU",
+                    ].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Oceania">
+                    {[
+                      "NSW",
+                      "VIC",
+                      "QLD",
+                      "WA",
+                      "SA",
+                      "TAS",
+                      "ACT",
+                      "NT",
+                      "New Zealand",
+                    ].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Asia">
+                    {[
+                      "Japan",
+                      "South Korea",
+                      "Philippines",
+                      "Southeast Asia",
+                    ].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label="Other">
+                    {["South America", "Middle East", "Africa"].map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                </select>
+              </div>
+            )}
+          {show("launch", "login", "start", "auto") && (
+            <ToggleRow
+              label="Launch at Login"
+              description="Start friendlies automatically when you log in"
+              checked={settings.autoLaunch}
+              onChange={() => toggle("autoLaunch")}
             />
-            <span className="text-xs text-gray-500 w-8 text-right tabular-nums">{Math.round((settings.notificationVolume / 0.35) * 100)}%</span>
-          </div>
+          )}
+          {show("close", "tray", "minimize", "quit") && (
+            <ToggleRow
+              label="Close to Tray"
+              description="Minimize to the system tray instead of quitting when you close the window"
+              checked={settings.closeToTray}
+              onChange={() => toggle("closeToTray")}
+            />
+          )}
         </div>
-        )}
-
-        {show('test notification', 'preview') && (
-        <div className={`flex items-center justify-between p-5 pl-10 ${!notifsEnabled ? 'opacity-40 pointer-events-none' : ''}`}>
-          <div>
-            <p className="text-sm font-medium text-gray-300">Test Notification</p>
-            <p className="text-xs text-gray-500 mt-0.5">Send a test notification to preview your settings</p>
-          </div>
-          <button
-            onClick={() => window.api.testNotification()}
-            disabled={!notifsEnabled}
-            className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white disabled:opacity-40"
-          >
-            Test
-          </button>
-        </div>
-        )}
-      </div>
       )}
 
-      {show('reduce', 'background', 'performance', 'polling', 'game') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        <ToggleRow
-          label="Reduce Background Activity"
-          description="Pause notifications and slow polling while in a game to minimize performance impact"
-          checked={settings.reduceBackgroundActivity}
-          onChange={() => toggle('reduceBackgroundActivity')}
-        />
-      </div>
+      {show(
+        "notification",
+        "friend online",
+        "play invite",
+        "sound",
+        "volume",
+        "test",
+      ) && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+          {show("notification", "desktop") && (
+            <ToggleRow
+              label="Notifications"
+              description="Enable desktop notifications"
+              checked={settings.showNotifications}
+              onChange={() => toggle("showNotifications")}
+            />
+          )}
+
+          {show("friend online", "notify", "notification") && (
+            <ToggleRow
+              label="Friend Online"
+              description="Notify when a friend comes online or enters a game"
+              checked={notifsEnabled && settings.notifyFriendOnline}
+              onChange={() => toggle("notifyFriendOnline")}
+              disabled={!notifsEnabled}
+              indent
+            />
+          )}
+
+          {show("play invite", "notify", "notification") && (
+            <ToggleRow
+              label="Play Invites"
+              description="Notify when a friend invites you to play"
+              checked={notifsEnabled && settings.notifyPlayInvite}
+              onChange={() => toggle("notifyPlayInvite")}
+              disabled={!notifsEnabled}
+              indent
+            />
+          )}
+
+          {show("notification sound", "sound effect") && (
+            <ToggleRow
+              label="Notification Sound"
+              description="Play a sound effect with notifications"
+              checked={notifsEnabled && settings.notificationSound}
+              onChange={() => toggle("notificationSound")}
+              disabled={!notifsEnabled}
+              indent
+            />
+          )}
+
+          {show("volume", "sound") && (
+            <div
+              className={`flex items-center justify-between p-5 pl-10 ${!notifsEnabled || !settings.notificationSound ? "opacity-40 pointer-events-none" : ""}`}
+            >
+              <div>
+                <p className="text-sm font-medium text-gray-300">Volume</p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Adjust notification sound volume
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={0}
+                  max={0.35}
+                  step={0.01}
+                  value={settings.notificationVolume}
+                  onChange={(e) => {
+                    const vol = parseFloat(e.target.value);
+                    setSettings((s) => ({ ...s, notificationVolume: vol }));
+                    window.api.updateSettings({ notificationVolume: vol });
+                  }}
+                  className="w-28 accent-[#21BA45] h-1.5 bg-[#333] rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-md"
+                />
+                <span className="text-xs text-gray-500 w-8 text-right tabular-nums">
+                  {Math.round((settings.notificationVolume / 0.35) * 100)}%
+                </span>
+              </div>
+            </div>
+          )}
+
+          {show("test notification", "preview") && (
+            <div
+              className={`flex items-center justify-between p-5 pl-10 ${!notifsEnabled ? "opacity-40 pointer-events-none" : ""}`}
+            >
+              <div>
+                <p className="text-sm font-medium text-gray-300">
+                  Test Notification
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Send a test notification to preview your settings
+                </p>
+              </div>
+              <button
+                onClick={() => window.api.testNotification()}
+                disabled={!notifsEnabled}
+                className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white disabled:opacity-40"
+              >
+                Test
+              </button>
+            </div>
+          )}
+        </div>
       )}
 
-      {show('privacy', 'friend request', 'hide', 'online status', 'location', 'discord', 'avatar', 'photo', 'connection type') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        <div className="p-5">
-          <p className="text-sm font-medium text-gray-300">Privacy</p>
-          <p className="text-xs text-gray-500 mt-0.5">Control what other players can see about you</p>
-        </div>
-        {show('friend request', 'disable', 'block', 'incoming') && (
-        <ToggleRow
-          label="Disable Friend Requests"
-          description="Block all incoming friend requests from other players"
-          checked={privacy.disableFriendRequests}
-          onChange={() => togglePrivacy('disableFriendRequests')}
-          indent
-        />
-        )}
-        {show('hide online', 'online status', 'offline', 'appear') && (
-        <ToggleRow
-          label="Hide Online Status"
-          description="Appear offline to all other players"
-          checked={privacy.hideOnlineStatus}
-          onChange={() => togglePrivacy('hideOnlineStatus')}
-          indent
-        />
-        )}
-        {show('hide location', 'region', 'location') && (
-        <ToggleRow
-          label="Hide Location"
-          description="Don't show your region to other players"
-          checked={privacy.hideRegion}
-          onChange={() => togglePrivacy('hideRegion')}
-          indent
-        />
-        )}
-        {show('hide discord', 'discord', 'non-friends', 'username') && (
-        <ToggleRow
-          label="Hide Discord from Non-Friends"
-          description="Only show your Discord username to accepted friends"
-          checked={privacy.hideDiscordUnlessFriends}
-          onChange={() => togglePrivacy('hideDiscordUnlessFriends')}
-          indent
-        />
-        )}
-        {show('hide discord photo', 'avatar', 'photo', 'character icon') && (
-        <ToggleRow
-          label="Hide Discord Photo"
-          description="Show your main character icon instead of your Discord avatar"
-          checked={privacy.hideAvatar}
-          onChange={() => togglePrivacy('hideAvatar')}
-          indent
-        />
-        )}
-        {show('connection type', 'wifi', 'ethernet') && (
+      {show("reduce", "background", "performance", "polling", "game") && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
           <ToggleRow
-            label="Hide Connection Type"
-            description="Don't show whether you're on Wi-Fi or Ethernet"
-            checked={privacy.hideConnectionType}
-            onChange={() => togglePrivacy('hideConnectionType')}
-            indent
+            label="Reduce Background Activity"
+            description="Pause notifications and slow polling while in a game to minimize performance impact"
+            checked={settings.reduceBackgroundActivity}
+            onChange={() => toggle("reduceBackgroundActivity")}
           />
-        )}
-      </div>
-      )}
-
-      {show('social', 'status preset', 'nudge', 'ggs', 'friendlies', 'chat') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        <div className="p-5">
-          <p className="text-sm font-medium text-gray-300">Social Features</p>
-          <p className="text-xs text-gray-500 mt-0.5">Control which social features are enabled</p>
         </div>
-        {show('status preset', 'down for friendlies', 'status') && (
-        <ToggleRow
-          label="Status Presets"
-          description="Show status presets like 'Down for friendlies' on your card and see others' statuses"
-          checked={!settings.disableStatuses}
-          onChange={() => toggle('disableStatuses')}
-          indent
-        />
-        )}
-        {show('nudge', 'ggs', 'quick message') && (
-        <ToggleRow
-          label="Nudges"
-          description="Receive and send quick messages like 'GGs' to other players"
-          checked={!settings.disableNudges}
-          onChange={() => toggle('disableNudges')}
-          indent
-        />
-        )}
-        {show('chat', 'chatroom', 'disable chat') && (
-        <ToggleRow
-          label="Chat"
-          description="Show the public chatroom tab"
-          checked={!settings.disableChat}
-          onChange={() => toggle('disableChat')}
-          indent
-        />
-        )}
-      </div>
       )}
 
-      {blockedUsers.length > 0 && show('block', 'unblock', 'blocked users') && (
+      {show(
+        "privacy",
+        "friend request",
+        "hide",
+        "online status",
+        "location",
+        "discord",
+        "avatar",
+        "photo",
+        "connection type",
+      ) && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+          <div className="p-5">
+            <p className="text-sm font-medium text-gray-300">Privacy</p>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Control what other players can see about you
+            </p>
+          </div>
+          {show("friend request", "disable", "block", "incoming") && (
+            <ToggleRow
+              label="Disable Friend Requests"
+              description="Block all incoming friend requests from other players"
+              checked={privacy.disableFriendRequests}
+              onChange={() => togglePrivacy("disableFriendRequests")}
+              indent
+            />
+          )}
+          {show("hide online", "online status", "offline", "appear") && (
+            <ToggleRow
+              label="Hide Online Status"
+              description="Appear offline to all other players"
+              checked={privacy.hideOnlineStatus}
+              onChange={() => togglePrivacy("hideOnlineStatus")}
+              indent
+            />
+          )}
+          {show("hide location", "region", "location") && (
+            <ToggleRow
+              label="Hide Location"
+              description="Don't show your region to other players"
+              checked={privacy.hideRegion}
+              onChange={() => togglePrivacy("hideRegion")}
+              indent
+            />
+          )}
+          {show("hide discord", "discord", "non-friends", "username") && (
+            <ToggleRow
+              label="Hide Discord from Non-Friends"
+              description="Only show your Discord username to accepted friends"
+              checked={privacy.hideDiscordUnlessFriends}
+              onChange={() => togglePrivacy("hideDiscordUnlessFriends")}
+              indent
+            />
+          )}
+          {show("hide discord photo", "avatar", "photo", "character icon") && (
+            <ToggleRow
+              label="Hide Discord Photo"
+              description="Show your main character icon instead of your Discord avatar"
+              checked={privacy.hideAvatar}
+              onChange={() => togglePrivacy("hideAvatar")}
+              indent
+            />
+          )}
+          {show("connection type", "wifi", "ethernet") && (
+            <ToggleRow
+              label="Hide Connection Type"
+              description="Don't show whether you're on Wi-Fi or Ethernet"
+              checked={privacy.hideConnectionType}
+              onChange={() => togglePrivacy("hideConnectionType")}
+              indent
+            />
+          )}
+          {show("mutual friends", "hide", "privacy") && (
+            <ToggleRow
+              label="Hide from Mutual Friends"
+              description="Don't appear in other players' mutual friends lists"
+              checked={privacy.hideMutualFriends}
+              onChange={() => togglePrivacy("hideMutualFriends")}
+              indent
+            />
+          )}
+        </div>
+      )}
+
+      {show(
+        "social",
+        "status preset",
+        "nudge",
+        "ggs",
+        "friendlies",
+        "chat",
+      ) && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+          <div className="p-5">
+            <p className="text-sm font-medium text-gray-300">Social Features</p>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Control which social features are enabled
+            </p>
+          </div>
+          {show("status preset", "down for friendlies", "status") && (
+            <ToggleRow
+              label="Status Presets"
+              description="Show status presets like 'Down for friendlies' on your card and see others' statuses"
+              checked={!settings.disableStatuses}
+              onChange={() => toggle("disableStatuses")}
+              indent
+            />
+          )}
+          {show("nudge", "ggs", "quick message") && (
+            <ToggleRow
+              label="Nudges"
+              description="Receive and send quick messages like 'GGs' to other players"
+              checked={!settings.disableNudges}
+              onChange={() => toggle("disableNudges")}
+              indent
+            />
+          )}
+          {show("chat", "chatroom", "disable chat") && (
+            <ToggleRow
+              label="Chat"
+              description="Show the public chatroom tab"
+              checked={!settings.disableChat}
+              onChange={() => toggle("disableChat")}
+              indent
+            />
+          )}
+        </div>
+      )}
+
+      {blockedUsers.length > 0 && show("block", "unblock", "blocked users") && (
         <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
           <div className="p-5">
             <p className="text-sm font-medium text-gray-300">Blocked Users</p>
             <p className="text-xs text-gray-500 mt-0.5">
-              Blocked users can't send you requests, invites, or appear on Discover
+              Blocked users can't send you requests, invites, or appear on
+              Discover
             </p>
           </div>
           {blockedUsers.map((b) => (
-            <div key={b.connectCode} className="flex items-center justify-between px-5 py-3">
+            <div
+              key={b.connectCode}
+              className="flex items-center justify-between px-5 py-3"
+            >
               <div className="flex items-center gap-3 min-w-0">
                 {b.avatarUrl ? (
-                  <img src={b.avatarUrl} alt="" className="w-7 h-7 rounded-full object-cover shrink-0 border border-[#2a2a2a]" />
+                  <img
+                    src={b.avatarUrl}
+                    alt=""
+                    className="w-7 h-7 rounded-full object-cover shrink-0 border border-[#2a2a2a]"
+                  />
                 ) : (
                   <div className="w-7 h-7 rounded-full bg-[#1a1a1a] border border-[#2a2a2a] flex items-center justify-center text-gray-600 text-[10px] font-bold shrink-0">
                     {b.connectCode.slice(0, 2)}
                   </div>
                 )}
                 <div className="min-w-0">
-                  <span className="font-mono font-bold text-white text-sm">{b.connectCode}</span>
+                  <span className="font-mono font-bold text-white text-sm">
+                    {b.connectCode}
+                  </span>
                   {b.displayName && (
-                    <p className="text-xs text-gray-500 truncate">{b.displayName}</p>
+                    <p className="text-xs text-gray-500 truncate">
+                      {b.displayName}
+                    </p>
                   )}
                 </div>
               </div>
@@ -519,107 +741,189 @@ export function Settings() {
                 disabled={unblocking === b.connectCode}
                 className="shrink-0 rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-white hover:bg-[#222] transition-colors disabled:opacity-40"
               >
-                {unblocking === b.connectCode ? '...' : 'Unblock'}
+                {unblocking === b.connectCode ? "..." : "Unblock"}
               </button>
             </div>
           ))}
         </div>
       )}
 
-      {show('troubleshoot', 'debug', 'logs', 'export', 'diagnostics') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
-        <div className="p-5 flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-gray-300">Troubleshooting</p>
-            <p className="text-xs text-gray-500 mt-0.5">Export application logs and metadata for debugging</p>
-          </div>
-          {import.meta.env.DEV ? (
-          <div className="inline-flex rounded-lg border border-[#2a2a2a] overflow-hidden">
-            <button
-              className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors"
-              onClick={() => { window.api.openLogsDirectory(); }}
-            >
-              Open Logs Directory
-            </button>
-            <button
-              className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors border-l border-[#2a2a2a] flex items-center gap-1.5"
-              onClick={async () => {
-                try {
-                  const filePath = await window.api.exportDiagnostics();
-                  if (filePath) flash();
-                } catch {}
-              }}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
-              </svg>
-              Export
-            </button>
-          </div>
-          ) : (
-          <button
-            className="px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#2a2a2a] text-sm text-gray-300 hover:bg-[#222] transition-colors flex items-center gap-1.5"
-            onClick={async () => {
-              try {
-                const filePath = await window.api.exportDiagnostics();
-                if (filePath) flash();
-              } catch {}
-            }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-              <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
-            </svg>
-            Export
-          </button>
-          )}
-        </div>
-      </div>
-      )}
-
-      {show('account', 'log out', 'logout', 'update', 'version') && (
-      <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
-        <h3 className="text-sm font-medium text-gray-300 mb-4">Account</h3>
-        <div className="flex gap-3">
-          <button
-            onClick={handleLogout}
-            className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20"
-          >
-            Log Out
-          </button>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => { setUpdateMsg(null); window.api.checkForUpdates(); }}
-              className="rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
-            >
-              Check for Updates
-            </button>
-            {updateMsg && (
-              <span className="text-xs font-medium text-[#21BA45]">{updateMsg}</span>
+      {show("troubleshoot", "debug", "logs", "export", "diagnostics") && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] divide-y divide-[#2a2a2a]">
+          <div className="p-5 flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-300">
+                Troubleshooting
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                Export application logs and metadata for debugging
+              </p>
+            </div>
+            {import.meta.env.DEV ? (
+              <div className="inline-flex rounded-lg border border-[#2a2a2a] overflow-hidden">
+                <button
+                  className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors"
+                  onClick={() => {
+                    window.api.openLogsDirectory();
+                  }}
+                >
+                  Open Logs Directory
+                </button>
+                <button
+                  className="px-4 py-2 bg-[#1a1a1a] text-sm text-gray-300 hover:bg-[#222] transition-colors border-l border-[#2a2a2a] flex items-center gap-1.5"
+                  onClick={async () => {
+                    try {
+                      const filePath = await window.api.exportDiagnostics();
+                      if (filePath) flash();
+                    } catch {}
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="w-3.5 h-3.5"
+                  >
+                    <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
+                  </svg>
+                  Export
+                </button>
+              </div>
+            ) : (
+              <button
+                className="px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#2a2a2a] text-sm text-gray-300 hover:bg-[#222] transition-colors flex items-center gap-1.5"
+                onClick={async () => {
+                  try {
+                    const filePath = await window.api.exportDiagnostics();
+                    if (filePath) flash();
+                  } catch {}
+                }}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className="w-3.5 h-3.5"
+                >
+                  <path d="M8 1a.75.75 0 0 1 .75.75v6.69l1.72-1.72a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 1.06-1.06l1.72 1.72V1.75A.75.75 0 0 1 8 1ZM2.75 11a.75.75 0 0 1 .75.75v1.5h9v-1.5a.75.75 0 0 1 1.5 0v1.5A1.5 1.5 0 0 1 12.5 14.75h-9A1.5 1.5 0 0 1 2 13.25v-1.5a.75.75 0 0 1 .75-.75Z" />
+                </svg>
+                Export
+              </button>
             )}
           </div>
         </div>
-      </div>
       )}
 
-      {sq && !['replay', 'directory', 'display region', 'region', 'launch', 'login', 'close', 'tray', 'slippi', 'launcher', 'install', 'path', 'custom', 'notification', 'friend online', 'play invite', 'sound', 'volume', 'test', 'reduce', 'background', 'performance', 'polling', 'game', 'privacy', 'friend request', 'hide', 'online status', 'location', 'discord', 'avatar', 'photo', 'connection type', 'social', 'status preset', 'nudge', 'ggs', 'friendlies', 'chat', 'chatroom', 'disable chat', 'block', 'unblock', 'blocked users', 'account', 'log out', 'logout', 'update', 'version'].some(t => t.includes(sq)) && (
-        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-12 text-center">
-          <p className="text-gray-500 text-sm">No settings match "{searchQuery}"</p>
+      {show("account", "log out", "logout", "update", "version") && (
+        <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
+          <h3 className="text-sm font-medium text-gray-300 mb-4">Account</h3>
+          <div className="flex gap-3">
+            <button
+              onClick={handleLogout}
+              className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20"
+            >
+              Log Out
+            </button>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => {
+                  setUpdateMsg(null);
+                  window.api.checkForUpdates();
+                }}
+                className="rounded-lg border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-[#222] hover:text-white"
+              >
+                Check for Updates
+              </button>
+              {updateMsg && (
+                <span className="text-xs font-medium text-[#21BA45]">
+                  {updateMsg}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
       )}
 
+      {sq &&
+        ![
+          "replay",
+          "directory",
+          "display region",
+          "region",
+          "launch",
+          "login",
+          "close",
+          "tray",
+          "slippi",
+          "launcher",
+          "install",
+          "path",
+          "custom",
+          "notification",
+          "friend online",
+          "play invite",
+          "sound",
+          "volume",
+          "test",
+          "reduce",
+          "background",
+          "performance",
+          "polling",
+          "game",
+          "privacy",
+          "friend request",
+          "hide",
+          "online status",
+          "location",
+          "discord",
+          "avatar",
+          "photo",
+          "connection type",
+          "social",
+          "status preset",
+          "nudge",
+          "ggs",
+          "friendlies",
+          "chat",
+          "chatroom",
+          "disable chat",
+          "block",
+          "unblock",
+          "blocked users",
+          "account",
+          "log out",
+          "logout",
+          "update",
+          "version",
+        ].some((t) => t.includes(sq)) && (
+          <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-12 text-center">
+            <p className="text-gray-500 text-sm">
+              No settings match "{searchQuery}"
+            </p>
+          </div>
+        )}
+
       {pStats && myCode && DEBUG_CONNECT_CODES.includes(myCode) && !sq && (
         <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
-          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Connection Health</h3>
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Connection Health
+          </h3>
           <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
             <div className="flex justify-between">
               <span className="text-gray-500">Realtime</span>
-              <span className={pStats.realtimeConnected ? 'text-[#21BA45]' : 'text-red-400'}>
-                {pStats.realtimeConnected ? 'Connected' : 'Disconnected'}
+              <span
+                className={
+                  pStats.realtimeConnected ? "text-[#21BA45]" : "text-red-400"
+                }
+              >
+                {pStats.realtimeConnected ? "Connected" : "Disconnected"}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-500">DB writes</span>
-              <span className="text-gray-300">{pStats.upsertOk} ok / {pStats.upsertFail} fail</span>
+              <span className="text-gray-300">
+                {pStats.upsertOk} ok / {pStats.upsertFail} fail
+              </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-500">Writes skipped</span>
@@ -627,11 +931,15 @@ export function Settings() {
             </div>
             <div className="flex justify-between">
               <span className="text-gray-500">Realtime tracks</span>
-              <span className="text-gray-300">{pStats.trackOk} ok / {pStats.trackFail} fail</span>
+              <span className="text-gray-300">
+                {pStats.trackOk} ok / {pStats.trackFail} fail
+              </span>
             </div>
           </div>
           {pStats.lastError && (
-            <p className="mt-2 text-[10px] text-red-400/70 truncate">Last error: {pStats.lastError}</p>
+            <p className="mt-2 text-[10px] text-red-400/70 truncate">
+              Last error: {pStats.lastError}
+            </p>
           )}
         </div>
       )}
@@ -640,50 +948,72 @@ export function Settings() {
         <DebugLaunchPanel />
       )}
 
-      {metrics && myCode && DEBUG_CONNECT_CODES.includes(myCode) && !sq && (() => {
-        const labelMap: Record<string, string> = {
-          Browser: 'Main process',
-          Tab: 'Renderer (UI)',
-          GPU: 'GPU compositing',
-          Utility: 'Network / utility',
-        };
-        const totalCpu = metrics.reduce((s, m) => s + m.cpu.percentCPUUsage, 0);
-        const totalMem = metrics.reduce((s, m) => s + m.memory.workingSetSize, 0);
-        const fmtCpu = (v: number) => v.toFixed(2).padStart(6);
-        const fmtMem = (v: number) => `${(v / 1024).toFixed(0)}`.padStart(4);
-        return (
-          <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
-            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Performance</h3>
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="text-[10px] text-gray-600">
-                  <td className="pb-2">Process</td>
-                  <td className="pb-2 text-right">CPU</td>
-                  <td className="pb-2 text-right">RAM</td>
-                </tr>
-              </thead>
-              <tbody className="font-mono tabular-nums">
-                {metrics.map((m) => (
-                  <tr key={m.pid}>
-                    <td className="text-gray-500 py-0.5 pr-4 font-sans">{labelMap[m.type] || m.type}</td>
-                    <td className="text-gray-300 py-0.5 text-right whitespace-pre">{fmtCpu(m.cpu.percentCPUUsage)}%</td>
-                    <td className="text-gray-300 py-0.5 text-right whitespace-pre">{fmtMem(m.memory.workingSetSize)} MB</td>
+      {metrics &&
+        myCode &&
+        DEBUG_CONNECT_CODES.includes(myCode) &&
+        !sq &&
+        (() => {
+          const labelMap: Record<string, string> = {
+            Browser: "Main process",
+            Tab: "Renderer (UI)",
+            GPU: "GPU compositing",
+            Utility: "Network / utility",
+          };
+          const totalCpu = metrics.reduce(
+            (s, m) => s + m.cpu.percentCPUUsage,
+            0,
+          );
+          const totalMem = metrics.reduce(
+            (s, m) => s + m.memory.workingSetSize,
+            0,
+          );
+          const fmtCpu = (v: number) => v.toFixed(2).padStart(6);
+          const fmtMem = (v: number) => `${(v / 1024).toFixed(0)}`.padStart(4);
+          return (
+            <div className="rounded-2xl border border-[#2a2a2a] bg-[#141414] p-5">
+              <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+                Performance
+              </h3>
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-[10px] text-gray-600">
+                    <td className="pb-2">Process</td>
+                    <td className="pb-2 text-right">CPU</td>
+                    <td className="pb-2 text-right">RAM</td>
                   </tr>
-                ))}
-                <tr className="border-t border-[#2a2a2a]">
-                  <td className="text-gray-400 font-medium pt-2 font-sans">Total</td>
-                  <td className="text-white font-medium pt-2 text-right whitespace-pre">{fmtCpu(totalCpu)}%</td>
-                  <td className="text-white font-medium pt-2 text-right whitespace-pre">{fmtMem(totalMem)} MB</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        );
-      })()}
+                </thead>
+                <tbody className="font-mono tabular-nums">
+                  {metrics.map((m) => (
+                    <tr key={m.pid}>
+                      <td className="text-gray-500 py-0.5 pr-4 font-sans">
+                        {labelMap[m.type] || m.type}
+                      </td>
+                      <td className="text-gray-300 py-0.5 text-right whitespace-pre">
+                        {fmtCpu(m.cpu.percentCPUUsage)}%
+                      </td>
+                      <td className="text-gray-300 py-0.5 text-right whitespace-pre">
+                        {fmtMem(m.memory.workingSetSize)} MB
+                      </td>
+                    </tr>
+                  ))}
+                  <tr className="border-t border-[#2a2a2a]">
+                    <td className="text-gray-400 font-medium pt-2 font-sans">
+                      Total
+                    </td>
+                    <td className="text-white font-medium pt-2 text-right whitespace-pre">
+                      {fmtCpu(totalCpu)}%
+                    </td>
+                    <td className="text-white font-medium pt-2 text-right whitespace-pre">
+                      {fmtMem(totalMem)} MB
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          );
+        })()}
 
-      <p className="text-center text-xs text-gray-600">
-      friendlies v{version}
-      </p>
+      <p className="text-center text-xs text-gray-600">friendlies v{version}</p>
     </div>
   );
 }
@@ -702,8 +1032,11 @@ function DebugLaunchPanel() {
     const unsub = window.api.onDirectConnectStatus((evt: any) => {
       const msg = evt.error ? `${evt.status}: ${evt.error}` : evt.status;
       setStatus(msg);
-      setActive(evt.status !== 'stopped' && evt.status !== 'error');
-      setLog((prev) => [...prev.slice(-50), `${new Date().toLocaleTimeString()} ${msg}`]);
+      setActive(evt.status !== "stopped" && evt.status !== "error");
+      setLog((prev) => [
+        ...prev.slice(-50),
+        `${new Date().toLocaleTimeString()} ${msg}`,
+      ]);
     });
     return unsub;
   }, []);
@@ -714,27 +1047,34 @@ function DebugLaunchPanel() {
 
   async function handleLaunch() {
     setLog([]);
-    setStatus('starting...');
+    setStatus("starting...");
     setActive(true);
-    const result = await window.api.startDirectConnect('MANG#0');
+    const result = await window.api.startDirectConnect("MANG#0");
     if (result?.error) {
       setStatus(`error: ${result.error}`);
       setActive(false);
-      setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} error: ${result.error}`]);
+      setLog((prev) => [
+        ...prev,
+        `${new Date().toLocaleTimeString()} error: ${result.error}`,
+      ]);
     }
   }
 
   async function handleStop() {
     await window.api.stopDirectConnect();
     setActive(false);
-    setStatus('stopped');
+    setStatus("stopped");
   }
 
   return (
     <div className="rounded-2xl border border-yellow-500/30 bg-[#141414] p-5">
-      <h3 className="text-xs font-semibold text-yellow-400 uppercase tracking-wider mb-3">Launch Dolphin (debug)</h3>
+      <h3 className="text-xs font-semibold text-yellow-400 uppercase tracking-wider mb-3">
+        Launch Dolphin (debug)
+      </h3>
       <p className="text-xs text-gray-500 mb-3">
-        Launches Dolphin and injects <span className="font-mono text-gray-400">MANG#0</span> as the direct connect code.
+        Launches Dolphin and injects{" "}
+        <span className="font-mono text-gray-400">MANG#0</span> as the direct
+        connect code.
       </p>
       <div className="flex items-center gap-3 mb-3">
         <button
@@ -742,7 +1082,7 @@ function DebugLaunchPanel() {
           disabled={active}
           className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-sm font-medium text-yellow-400 transition-colors hover:bg-yellow-500/20 disabled:opacity-40"
         >
-          {active ? 'Running...' : 'Launch'}
+          {active ? "Running..." : "Launch"}
         </button>
         {active && (
           <button
@@ -753,11 +1093,15 @@ function DebugLaunchPanel() {
           </button>
         )}
         {status && (
-          <span className={`text-xs font-medium ${
-            status.startsWith('error') ? 'text-red-400' :
-            status === 'stopped' ? 'text-gray-500' :
-            'text-yellow-400'
-          }`}>
+          <span
+            className={`text-xs font-medium ${
+              status.startsWith("error")
+                ? "text-red-400"
+                : status === "stopped"
+                  ? "text-gray-500"
+                  : "text-yellow-400"
+            }`}
+          >
             {status}
           </span>
         )}
@@ -767,7 +1111,7 @@ function DebugLaunchPanel() {
           ref={logRef}
           className="mt-2 max-h-32 overflow-y-auto rounded-lg bg-[#0a0a0a] border border-[#2a2a2a] p-3 text-[10px] text-gray-500 font-mono leading-relaxed"
         >
-          {log.join('\n')}
+          {log.join("\n")}
         </pre>
       )}
     </div>
@@ -790,7 +1134,9 @@ function ToggleRow({
   indent?: boolean;
 }) {
   return (
-    <div className={`flex items-center justify-between p-5 ${indent ? 'pl-10' : ''} ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div
+      className={`flex items-center justify-between p-5 ${indent ? "pl-10" : ""} ${disabled ? "opacity-40 pointer-events-none" : ""}`}
+    >
       <div>
         <p className="text-sm font-medium text-gray-300">{label}</p>
         <p className="text-xs text-gray-500 mt-0.5">{description}</p>
@@ -799,12 +1145,12 @@ function ToggleRow({
         onClick={onChange}
         disabled={disabled}
         className={`relative w-11 h-6 rounded-full transition-colors ${
-          checked ? 'bg-[#21BA45]' : 'bg-[#333]'
+          checked ? "bg-[#21BA45]" : "bg-[#333]"
         }`}
       >
         <span
           className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
-            checked ? 'translate-x-5' : ''
+            checked ? "translate-x-5" : ""
           }`}
         />
       </button>

--- a/apps/agent/src/renderer/pages/Settings.tsx
+++ b/apps/agent/src/renderer/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { isGameActive } from '../App';
+import { version } from '../../../package.json';
 
 interface SettingsState {
   replayDir: string;
@@ -631,7 +632,7 @@ export function Settings() {
       })()}
 
       <p className="text-center text-xs text-gray-600">
-      friendlies v1.0.39
+      friendlies v{version}
       </p>
     </div>
   );

--- a/apps/agent/src/renderer/types.d.ts
+++ b/apps/agent/src/renderer/types.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import type { ElectronAPI } from '../preload';
 
 declare global {

--- a/apps/agent/src/startgg/cashbox.ts
+++ b/apps/agent/src/startgg/cashbox.ts
@@ -15,6 +15,7 @@ import {
 import { getStartGgUserToken, getStartGgWebCookies, refreshStartGgWebCookies, startGgSessionFetch, reLoginStartGgSession, getStartGgUserInfo } from '../startgg-auth';
 import { supabase } from '../supabase';
 import { getCurrentUser } from '../auth';
+import { cashboxLog } from '../logger';
 
 setStartGgUserTokenProvider(getStartGgUserToken);
 setStartGgWebCookieProvider(getStartGgWebCookies);
@@ -128,6 +129,7 @@ async function entrantIdForUserInEvent(
     if (r.errors?.length || !r.data?.tournament?.participants) {
       const isRateLimit = r.errors?.some((e) => /rate.?limit/i.test(e.message)) ?? false;
       console.warn('[cashbox] entrantIdForUserInEvent failed at page', page, isRateLimit ? '(RATE LIMITED)' : '', 'errors:', r.errors);
+      cashboxLog.warn('entrantIdForUserInEvent failed at page', page, isRateLimit ? '(RATE LIMITED)' : '', 'errors:', r.errors);
       return { found: false, rateLimited: isRateLimit };
     }
     const pg = r.data.tournament.participants;
@@ -145,6 +147,7 @@ async function entrantIdForUserInEvent(
     page++;
   }
   console.warn('[cashbox] entrantIdForUserInEvent: user', userId, 'not found in', tournamentSlug, 'event', eventId, '(scanned', page - 1, 'pages)');
+  cashboxLog.warn('entrantIdForUserInEvent: user', userId, 'not found in', tournamentSlug, 'event', eventId, '(scanned', page - 1, 'pages)');
   return { found: false, rateLimited: false };
 }
 
@@ -233,17 +236,19 @@ async function resolveMapValueToEntrantId(
 async function resolveStartGgUserIdFromProfile(): Promise<string | null> {
   try {
     const user = await getCurrentUser();
-    if (!user) { console.log('[cashbox] resolveStartGgUserIdFromProfile: no current user'); return null; }
+    if (!user) { console.log('[cashbox] resolveStartGgUserIdFromProfile: no current user'); cashboxLog.info('resolveStartGgUserIdFromProfile: no current user'); return null; }
     const { data, error } = await supabase
       .from('profiles')
       .select('startgg_user_id')
       .eq('id', user.id)
       .maybeSingle();
-    if (error) console.warn('[cashbox] resolveStartGgUserIdFromProfile query error:', error.message);
+    if (error) { console.warn('[cashbox] resolveStartGgUserIdFromProfile query error:', error.message); cashboxLog.warn('resolveStartGgUserIdFromProfile query error:', error.message); }
     console.log('[cashbox] resolveStartGgUserIdFromProfile:', { userId: user.id, startgg_user_id: data?.startgg_user_id ?? '(null)' });
+    cashboxLog.info('resolveStartGgUserIdFromProfile:', { userId: user.id, startgg_user_id: data?.startgg_user_id ?? '(null)' });
     return data?.startgg_user_id || null;
   } catch (e: any) {
     console.error('[cashbox] resolveStartGgUserIdFromProfile exception:', e?.message);
+    cashboxLog.error('resolveStartGgUserIdFromProfile exception:', e?.message);
     return null;
   }
 }
@@ -1079,7 +1084,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
   if (!resolved.ok) {
     if (isRateLimitError(resolved.message)) {
       const cached = getCachedSnapshot(connectCode);
-      if (cached) { console.log('[cashbox] serving cached snapshot (event resolve rate-limited)'); return cached; }
+      if (cached) { console.log('[cashbox] serving cached snapshot (event resolve rate-limited)'); cashboxLog.info('serving cached snapshot (event resolve rate-limited)'); return cached; }
     }
     return { ok: false, reason: 'config', message: resolved.message, giveawayRegisterUrl };
   }
@@ -1100,6 +1105,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
 
   if (!entrantId && profileUserId) {
     console.log('[cashbox] resolved startgg_user_id from Supabase profile:', profileUserId);
+    cashboxLog.info('resolved startgg_user_id from Supabase profile:', profileUserId);
     const result = await entrantIdForUserInEvent(profileUserId, meta.tournamentSlug, meta.eventId, userToken);
     if (result.found) entrantId = result.id;
     else if (result.rateLimited) wasRateLimited = true;
@@ -1109,6 +1115,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
     const localInfo = getStartGgUserInfo();
     if (localInfo.userId && localInfo.userId !== profileUserId) {
       console.log('[cashbox] trying local store userId:', localInfo.userId);
+      cashboxLog.info('trying local store userId:', localInfo.userId);
       const result = await entrantIdForUserInEvent(localInfo.userId, meta.tournamentSlug, meta.eventId, userToken);
       if (result.found) entrantId = result.id;
       else if (result.rateLimited) wasRateLimited = true;
@@ -1118,7 +1125,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
   if (!entrantId) {
     if (wasRateLimited) {
       const cached = getCachedSnapshot(connectCode);
-      if (cached) { console.log('[cashbox] serving cached snapshot (entrant resolve rate-limited)'); return cached; }
+      if (cached) { console.log('[cashbox] serving cached snapshot (entrant resolve rate-limited)'); cashboxLog.info('serving cached snapshot (entrant resolve rate-limited)'); return cached; }
       return {
         ok: false,
         reason: 'api',
@@ -1145,7 +1152,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
   if (!pack.ok) {
     if (isRateLimitError(pack.message)) {
       const cached = getCachedSnapshot(connectCode);
-      if (cached) { console.log('[cashbox] serving cached snapshot (sets fetch rate-limited)'); return cached; }
+      if (cached) { console.log('[cashbox] serving cached snapshot (sets fetch rate-limited)'); cashboxLog.info('serving cached snapshot (sets fetch rate-limited)'); return cached; }
     }
     return { ok: false, reason: 'api', message: pack.message, giveawayRegisterUrl };
   }
@@ -1214,7 +1221,7 @@ export async function getCashboxSnapshot(connectCode: string, userToken?: string
       ? hydrateNextMatchOpponent(nextMatch, entrantId, userToken)
       : Promise.resolve(),
     pgId
-      ? fetchPhaseGroupPool(String(pgId), String(entrantId), userToken).catch((e) => { console.error('[cashbox] fetchPhaseGroupPool', e); return null; })
+      ? fetchPhaseGroupPool(String(pgId), String(entrantId), userToken).catch((e) => { console.error('[cashbox] fetchPhaseGroupPool', e); cashboxLog.error('fetchPhaseGroupPool', e); return null; })
       : Promise.resolve(null),
     nextMatch?.phaseGroupId
       ? fetchPhaseGroupRestJson(nextMatch.phaseGroupId).catch(() => null)
@@ -1323,13 +1330,16 @@ export async function reportBracketSet(
     if (body.errors?.length) {
       const msg = body.errors.map((e: any) => e.message).join('; ');
       console.error('[cashbox] reportBracketSet errors:', msg);
+      cashboxLog.error('reportBracketSet errors:', msg);
       return { ok: false, message: msg };
     }
     const set = body.data?.reportBracketSet;
     console.log('[cashbox] reportBracketSet ok, state:', set?.state);
+    cashboxLog.info('reportBracketSet ok, state:', set?.state);
     return { ok: true, state: set?.state ?? null };
   } catch (e: any) {
     console.error('[cashbox] reportBracketSet', e);
+    cashboxLog.error('reportBracketSet', e);
     return { ok: false, message: e?.message || 'Network error' };
   }
 }

--- a/apps/agent/src/startgg/client.ts
+++ b/apps/agent/src/startgg/client.ts
@@ -1,4 +1,5 @@
 const START_GG_ENDPOINT = 'https://api.start.gg/gql/alpha';
+import { startggLog } from '../logger';
 
 export interface StartGgGraphqlResult<T> {
   data: T | null;
@@ -24,6 +25,7 @@ export async function startGgGraphql<T>(
   _lastTokenSource = userToken ? 'oauth' : token ? 'env' : 'none';
   if (!token) {
     console.warn(`[startgg-gql] ${operationName ?? 'query'}: NO TOKEN AVAILABLE`);
+    startggLog.warn(`${operationName ?? 'query'}: NO TOKEN AVAILABLE`);
     return { data: null, errors: [{ message: 'No start.gg token available (link your start.gg account or set START_GG_TOKEN)' }] };
   }
 

--- a/apps/agent/src/startgg/www-rest-moderation.ts
+++ b/apps/agent/src/startgg/www-rest-moderation.ts
@@ -1,4 +1,5 @@
 import { getStartGgToken, startGgGraphql } from './client';
+import { startggLog } from '../logger';
 
 const WWW_ORIGIN = 'https://www.start.gg';
 
@@ -8,6 +9,7 @@ let _sessionFetcher: SessionFetcher | null = null;
 export function setStartGgSessionFetcher(fn: SessionFetcher): void {
   _sessionFetcher = fn;
   console.log('[startgg rest] sessionFetcher registered:', !!fn);
+  startggLog.info('sessionFetcher registered:', !!fn);
 }
 
 type UserTokenProvider = () => Promise<string | null>;
@@ -227,11 +229,13 @@ export async function fetchPhaseGroupRestJson(phaseGroupId: string): Promise<unk
     const res = await fetch(url, { method: 'GET', headers });
     if (!res.ok) {
       console.warn('[startgg rest] phase_group HTTP', res.status, await res.text().catch(() => ''));
+      startggLog.warn('phase_group HTTP', res.status);
       return null;
     }
     return await res.json();
   } catch (e) {
     console.error('[startgg rest] phase_group', e);
+    startggLog.error('phase_group', e);
     return null;
   }
 }
@@ -275,6 +279,7 @@ async function fetchSetRestJson(setId: string): Promise<unknown | null> {
       const cfCache = res.headers.get('cf-cache-status') ?? '?';
       if (!res.ok) {
         console.warn('[startgg rest] set HTTP', res.status, `cf=${cfCache}`, await res.text().catch(() => ''));
+        startggLog.warn('set HTTP', res.status, `cf=${cfCache}`);
         return null;
       }
       const parsed = await parseSetJsonWithRetry(res);
@@ -291,12 +296,15 @@ async function fetchSetRestJson(setId: string): Promise<unknown | null> {
     const fallback = lastGoodSetPayloads.get(cacheKey);
     if (fallback && Date.now() - fallback.at < 30_000) {
       console.warn(`[startgg rest] set ${setId}: malformed JSON, using cached payload (${Date.now() - fallback.at}ms old)`);
+      startggLog.warn(`set ${setId}: malformed JSON, using cached payload (${Date.now() - fallback.at}ms old)`);
       return fallback.payload;
     }
     console.warn(`[startgg rest] set ${setId}: malformed JSON and no fresh cache available`);
+    startggLog.warn(`set ${setId}: malformed JSON and no fresh cache available`);
     return null;
   } catch (e) {
     console.error('[startgg rest] set fetch', e);
+    startggLog.error('set fetch', e);
     return null;
   }
 }
@@ -337,6 +345,7 @@ function logActiveTasks(tasks: RawSetTask[]): void {
   if (!summary || summary === _lastLoggedSummary) return;
   _lastLoggedSummary = summary;
   console.log(`[startgg rest] active tasks: ${summary}`);
+  startggLog.info(`active tasks: ${summary}`);
 }
 
 /**
@@ -369,6 +378,7 @@ export async function fetchRawSetTasks(
     tasks = extractRawSetTasksFromPayload(setPayload, numericSetId);
     if (tasks.length === 0) tasks = extractRawSetTasksFromPayload(setPayload, 0);
     console.log(`[startgg rest] set ${setId}: tasks=${tasks.length} (${Date.now() - t0}ms)`);
+    startggLog.info(`set ${setId}: tasks=${tasks.length} (${Date.now() - t0}ms)`);
   }
 
   if (tasks.length === 0) {
@@ -394,6 +404,7 @@ function parseTaskMutationResponse(
   const tasks = extractRawSetTasksFromPayload(json, 0);
   const topKeys = Object.keys(j).join(',');
   console.log(`[startgg rest] PUT response: topKeys=[${topKeys}] extractedTasks=${tasks.length}`);
+  startggLog.info(`PUT response: topKeys=[${topKeys}] extractedTasks=${tasks.length}`);
   return { ok: true, tasks };
 }
 
@@ -408,12 +419,14 @@ async function putTaskWithRetry(
       const headers = await wwwRestHeaders(useSession);
       if (attempt === 0) {
         console.log(`[startgg rest] PUT ${label} auth:${headers.Authorization?.slice(0, 20) || '(none)'} cookie:${useSession ? 'session' : headers.Cookie ? 'yes' : 'no'}`);
+        startggLog.info(`PUT ${label} auth:${headers.Authorization?.slice(0, 20) || '(none)'} cookie:${useSession ? 'session' : headers.Cookie ? 'yes' : 'no'}`);
       }
       const doFetch = _sessionFetcher ?? fetch;
       const res = await doFetch(url, { method: 'PUT', headers, body: JSON.stringify(body), cache: 'no-store' as RequestCache });
       if (!res.ok) {
         const txt = await res.text().catch(() => '');
         console.warn(`[startgg rest] ${label} HTTP`, res.status, txt.slice(0, 200));
+        startggLog.warn(`${label} HTTP`, res.status, txt.slice(0, 200));
         return { ok: false, message: txt.slice(0, 400) || `HTTP ${res.status}`, status: res.status };
       }
       const json = await res.json().catch(() => null);
@@ -421,16 +434,18 @@ async function putTaskWithRetry(
       if (!result.ok && result.message === 'Login is required') {
         if (attempt === 0 && _cookieRefresher) {
           console.log('[startgg rest] session expired, refreshing cookies and retrying…');
+          startggLog.info('session expired, refreshing cookies and retrying…');
           await _cookieRefresher();
           continue;
         }
         if (attempt === 1 && _sessionReAuthenticator) {
           console.log('[startgg rest] cookie refresh insufficient, opening browser for re-login…');
+          startggLog.info('cookie refresh insufficient, opening browser for re-login…');
           await _sessionReAuthenticator();
           continue;
         }
       }
-      if (!result.ok) console.warn(`[startgg rest] ${label} rejected:`, result.message);
+      if (!result.ok) { console.warn(`[startgg rest] ${label} rejected:`, result.message); startggLog.warn(`${label} rejected:`, result.message); }
       if (result.ok && result.tasks.length > 0) {
         for (const t of result.tasks) {
           const sid = String(t.setId);

--- a/apps/agent/src/updater.ts
+++ b/apps/agent/src/updater.ts
@@ -1,13 +1,14 @@
-import { autoUpdater, UpdateInfo } from 'electron-updater';
-import { app, BrowserWindow } from 'electron';
+import { autoUpdater, UpdateInfo } from "electron-updater";
+import { app, BrowserWindow } from "electron";
+import { updaterLog } from "./logger";
 
 export type UpdateStatus =
-  | { state: 'checking' }
-  | { state: 'available'; version: string; releaseNotes?: string }
-  | { state: 'not-available' }
-  | { state: 'downloading'; percent: number }
-  | { state: 'downloaded'; version: string }
-  | { state: 'error'; message: string };
+  | { state: "checking" }
+  | { state: "available"; version: string; releaseNotes?: string }
+  | { state: "not-available" }
+  | { state: "downloading"; percent: number }
+  | { state: "downloaded"; version: string }
+  | { state: "error"; message: string };
 
 let sender: ((status: UpdateStatus) => void) | null = null;
 
@@ -19,46 +20,51 @@ export function initAutoUpdater(win: BrowserWindow): void {
   const send = (status: UpdateStatus) => {
     if (sender) sender(status);
     try {
-      if (!win.isDestroyed()) win.webContents.send('updater:status', status);
+      if (!win.isDestroyed()) win.webContents.send("updater:status", status);
     } catch {}
   };
 
-  autoUpdater.on('checking-for-update', () => send({ state: 'checking' }));
+  autoUpdater.on("checking-for-update", () => send({ state: "checking" }));
 
-  autoUpdater.on('update-available', (info: UpdateInfo) => {
-    send({ state: 'available', version: info.version });
+  autoUpdater.on("update-available", (info: UpdateInfo) => {
+    send({ state: "available", version: info.version });
   });
 
-  autoUpdater.on('update-not-available', () => send({ state: 'not-available' }));
+  autoUpdater.on("update-not-available", () =>
+    send({ state: "not-available" }),
+  );
 
-  autoUpdater.on('download-progress', (progress) => {
-    send({ state: 'downloading', percent: Math.round(progress.percent) });
+  autoUpdater.on("download-progress", (progress) => {
+    send({ state: "downloading", percent: Math.round(progress.percent) });
   });
 
-  autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
-    send({ state: 'downloaded', version: info.version });
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    send({ state: "downloaded", version: info.version });
   });
 
-  autoUpdater.on('error', (err) => {
+  autoUpdater.on("error", (err) => {
     const msg = err?.message ?? String(err);
-    if (msg.includes('404') || msg.includes('net::ERR_')) {
-      console.warn('[updater] transient error, will retry:', msg);
+    if (msg.includes("404") || msg.includes("net::ERR_")) {
+      console.warn("[updater] transient error, will retry:", msg);
+      updaterLog.warn("transient error, will retry:", msg);
       return;
     }
-    send({ state: 'error', message: msg });
+    send({ state: "error", message: msg });
   });
 }
 
 export function checkForUpdates(): void {
-  autoUpdater.checkForUpdates().catch((e) =>
-    console.error('[updater] checkForUpdates failed:', e),
-  );
+  autoUpdater.checkForUpdates().catch((e) => {
+    console.error("[updater] checkForUpdates failed:", e);
+    updaterLog.error("checkForUpdates failed:", e);
+  });
 }
 
 export function downloadUpdate(): void {
-  autoUpdater.downloadUpdate().catch((e) =>
-    console.error('[updater] downloadUpdate failed:', e),
-  );
+  autoUpdater.downloadUpdate().catch((e) => {
+    console.error("[updater] downloadUpdate failed:", e);
+    updaterLog.error("downloadUpdate failed:", e);
+  });
 }
 
 export function quitAndInstall(): void {

--- a/apps/agent/src/watcher.ts
+++ b/apps/agent/src/watcher.ts
@@ -5,6 +5,7 @@ import chokidar from 'chokidar';
 
 import { ENABLE_IDENTITY_BLACKLIST_ENFORCEMENT } from './identity-enforcement';
 import { getIdentity } from './identity';
+import { watcherLog, identityLog } from './logger';
 import { normalizeConnectCode } from './presence-logic';
 import { supabase } from './supabase';
 
@@ -67,6 +68,7 @@ function drainPendingReplays(): void {
   const batch = _pendingReplays.splice(0);
   if (batch.length === 0) return;
   console.log(`[watcher] Draining ${batch.length} deferred replay(s)`);
+  watcherLog.info(`Draining ${batch.length} deferred replay(s)`);
   for (const item of batch) {
     void (async () => {
       try {
@@ -74,6 +76,7 @@ function drainPendingReplays(): void {
         if (info) item.onOpponent(info);
       } catch (e) {
         console.error('deferred replay processing failed', e);
+        watcherLog.error('deferred replay processing failed', e);
       }
     })();
   }
@@ -113,6 +116,7 @@ export async function processNewReplay(
     );
     if (playersWithCodes.length === 0) {
       console.log('[watcher] Skipping offline/local replay (no connect codes)');
+      watcherLog.info('Skipping offline/local replay (no connect codes)');
       return null;
     }
 
@@ -123,8 +127,10 @@ export async function processNewReplay(
     if (localPlayer) {
       consecutiveMismatches = 0;
       console.log(`[watcher] Matched local player at port ${localPlayer.port} (code ${localNorm}, char ${localPlayer.characterId})`);
+      watcherLog.info(`Matched local player at port ${localPlayer.port}`, { code: localNorm, char: localPlayer.characterId });
     } else {
       console.log(`[watcher] Local player not found for ${localNorm} — players: ${playersWithCodes.map((p) => normalizeConnectCode(p.connectCode || '')).join(', ')}`);
+      watcherLog.info(`Local player not found for ${localNorm}`, { players: playersWithCodes.map((p) => normalizeConnectCode(p.connectCode || '')) });
     }
 
     // Identity mismatch detection: only for live replays (not backfill)
@@ -139,6 +145,7 @@ export async function processNewReplay(
     ) {
       if (isSpectateReplay(filePath)) {
         console.log(`[identity] Skipping mismatch check — spectate replay: ${path.basename(filePath)}`);
+        identityLog.info(`Skipping mismatch check — spectate replay: ${path.basename(filePath)}`);
       } else {
         const actualCodes = humans
           .map((p) => normalizeConnectCode(p.connectCode || ''))
@@ -155,8 +162,10 @@ export async function processNewReplay(
 
         if (isEncodingMismatch) {
           console.log(`[identity] Encoding-only mismatch for ${localNorm} — not a spoof`);
+          identityLog.info(`Encoding-only mismatch for ${localNorm} — not a spoof`);
         } else if (freshMatchesReplay) {
           console.log(`[identity] user.json updated to ${freshNorm} which matches replay — account switch, not a spoof`);
+          identityLog.info(`user.json updated to ${freshNorm} which matches replay — account switch, not a spoof`);
         } else if (actualCodes.length > 0) {
           consecutiveMismatches++;
           const replayName = path.basename(filePath);
@@ -164,6 +173,7 @@ export async function processNewReplay(
             `[identity] Mismatch strike ${consecutiveMismatches}/${MISMATCH_STRIKE_THRESHOLD}:`,
             { claimedCode: localNorm, actualCode: actualCodes[0], replayFile: replayName },
           );
+          identityLog.warn(`Mismatch strike ${consecutiveMismatches}/${MISMATCH_STRIKE_THRESHOLD}`, { claimedCode: localNorm, actualCode: actualCodes[0], replayFile: replayName });
 
           if (consecutiveMismatches >= MISMATCH_STRIKE_THRESHOLD) {
             const mismatch: IdentityMismatch = {
@@ -172,6 +182,7 @@ export async function processNewReplay(
               replayFile: replayName,
             };
             console.warn('[identity] MISMATCH CONFIRMED after consecutive strikes:', mismatch);
+            identityLog.warn('MISMATCH CONFIRMED after consecutive strikes', mismatch);
             try {
               const { data: userData } = await supabase.auth.getUser();
               if (userData?.user) {
@@ -194,6 +205,7 @@ export async function processNewReplay(
               }
             } catch (e) {
               console.error('Failed to blacklist/unlink spoofed profile', e);
+              identityLog.error('Failed to blacklist/unlink spoofed profile', e);
             }
             if (onIdentityMismatch) onIdentityMismatch(mismatch);
           }
@@ -225,6 +237,7 @@ export async function processNewReplay(
         setLastPlayedCharacterId(localPlayer.characterId);
       } catch (e) {
         console.error('presence character notify failed', e);
+        watcherLog.error('presence character notify failed', e);
       }
     }
 
@@ -322,6 +335,7 @@ export async function processNewReplay(
       .upsert(row, { onConflict: 'user_id,replay_filename' });
     if (error) {
       console.error('matches upsert failed', error);
+      watcherLog.error('matches upsert failed', error);
     }
 
     return {
@@ -332,6 +346,7 @@ export async function processNewReplay(
     };
   } catch (e) {
     console.error('processNewReplay failed', e);
+    watcherLog.error('processNewReplay failed', e);
     return null;
   }
 }
@@ -345,9 +360,11 @@ export function startWatcher(
     stopWatcher();
     if (!fs.existsSync(replayDir)) {
       console.error('Replay directory missing:', replayDir);
+      watcherLog.error('Replay directory missing:', replayDir);
       return;
     }
     console.log(`[watcher] Starting — dir="${replayDir}" code="${localConnectCode}"`);
+    watcherLog.info('Starting', { dir: replayDir, code: localConnectCode });
     peeked.clear();
 
     watcher = chokidar.watch(replayDir, {
@@ -357,15 +374,18 @@ export function startWatcher(
 
     watcher.on('ready', () => {
       console.log('[watcher] Ready and watching for new replays');
+      watcherLog.info('Ready and watching for new replays');
     });
     watcher.on('error', (err) => {
       console.error('[watcher] Error:', err);
+      watcherLog.error('Error:', err);
     });
     watcher.on('add', (filePath: string) => {
       if (!filePath.toLowerCase().endsWith('.slp')) return;
       if (peeked.has(filePath)) return;
       peeked.add(filePath);
       console.log(`[watcher] New replay detected: ${path.basename(filePath)}`);
+      watcherLog.info(`New replay detected: ${path.basename(filePath)}`);
 
       // Immediate presence peek after brief delay for .slp header flush
       setTimeout(() => {
@@ -374,6 +394,7 @@ export function startWatcher(
             const info = await processNewReplay(filePath, localConnectCode, true, { presenceOnly: true });
             if (info) {
               console.log(`[watcher] Presence peek: ${info.connectCode} mode=${info.gameMode}`);
+              watcherLog.info(`Presence peek: ${info.connectCode} mode=${info.gameMode}`);
               try {
                 const { setLastOpponent } = require('./presence') as {
                   setLastOpponent: (code: string, characterId?: number, gameMode?: string | null) => void;
@@ -381,6 +402,7 @@ export function startWatcher(
                 setLastOpponent(info.connectCode, info.characterId, info.gameMode);
               } catch (e) {
                 console.error('setLastOpponent from peek failed', e);
+                watcherLog.error('setLastOpponent from peek failed', e);
               }
             }
           } catch { /* file not readable yet — full processing will handle it */ }
@@ -398,15 +420,18 @@ export function startWatcher(
           const info = await processNewReplay(filePath, localConnectCode, true);
           if (info) {
             console.log(`[watcher] Opponent: ${info.connectCode} (char ${info.characterId})`);
+            watcherLog.info(`Opponent: ${info.connectCode} (char ${info.characterId})`);
             onOpponent(info);
           }
         } catch (e) {
           console.error('watcher add handler failed', e);
+          watcherLog.error('watcher add handler failed', e);
         }
       })();
     });
   } catch (e) {
     console.error('startWatcher failed', e);
+    watcherLog.error('startWatcher failed', e);
   }
 }
 
@@ -432,6 +457,7 @@ export async function backfillRecentReplays(
       .slice(0, BACKFILL_MAX_PER_CALL);
 
     console.log(`[backfill] Processing ${filtered.length} replays (max ${BACKFILL_MAX_PER_CALL} per call)`);
+    watcherLog.info(`Backfill processing ${filtered.length} replays`);
 
     for (const f of filtered) {
       try {
@@ -441,7 +467,8 @@ export async function backfillRecentReplays(
       } catch { /* skip bad replays */ }
     }
     console.log(`[backfill] Done — ${processed}/${filtered.length} processed`);
-  } catch (e) { console.error('backfillRecentReplays', e); }
+    watcherLog.info(`Backfill done — ${processed}/${filtered.length} processed`);
+  } catch (e) { console.error('backfillRecentReplays', e); watcherLog.error('backfillRecentReplays', e); }
   return { processed, oldestMs };
 }
 
@@ -479,6 +506,7 @@ export function stopWatcher(): void {
     void watcher?.close();
   } catch (e) {
     console.error('stopWatcher failed', e);
+    watcherLog.error('stopWatcher failed', e);
   }
   watcher = null;
   peeked.clear();

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,14 @@
     },
     "apps/agent": {
       "name": "@slippi-friends/agent",
-      "version": "0.1.65",
+      "version": "1.0.39",
       "dependencies": {
         "@slippi/slippi-js": "^9.0.0",
         "@supabase/supabase-js": "^2.49.0",
+        "@types/archiver": "^7.0.0",
+        "archiver": "^7.0.1",
         "chokidar": "^4.0.0",
+        "electron-log": "^5.4.3",
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.3",
         "find-process": "^1.4.7",
@@ -258,21 +261,84 @@
         "electron-builder-squirrel-windows": "24.13.3"
       }
     },
+    "apps/agent/node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/agent/node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "apps/agent/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "apps/agent/node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "apps/agent/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "apps/agent/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "apps/agent/node_modules/builder-util": {
@@ -312,6 +378,33 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "apps/agent/node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/agent/node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "apps/agent/node_modules/dir-compare": {
@@ -408,6 +501,228 @@
         "fs-extra": "^10.1.0"
       }
     },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/agent/node_modules/electron-builder-squirrel-windows/node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "apps/agent/node_modules/electron-publish": {
       "version": "24.13.1",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
@@ -437,6 +752,40 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "apps/agent/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/agent/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "apps/agent/node_modules/http-proxy-agent": {
@@ -494,6 +843,60 @@
         "node": ">=10"
       }
     },
+    "apps/agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "apps/agent/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "apps/agent/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
+    },
+    "apps/agent/node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "apps/agent/node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "apps/agent/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -502,6 +905,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "apps/agent/node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "apps/web": {
@@ -1479,7 +1895,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1495,7 +1910,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1506,7 +1920,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1517,12 +1930,10 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1538,7 +1949,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1552,7 +1962,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1732,7 +2141,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2190,6 +2598,14 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -2340,6 +2756,14 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -2493,6 +2917,17 @@
       "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "dev": true,
@@ -2551,7 +2986,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2593,75 +3027,6 @@
       "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
       "license": "MIT"
     },
-    "node_modules/archiver": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.4",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "dev": true,
@@ -2701,7 +3066,6 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-exit-hook": {
@@ -2788,9 +3152,93 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3185,21 +3633,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -3296,7 +3729,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/crc": {
@@ -3310,9 +3742,7 @@
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -3320,22 +3750,8 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/crc32-stream": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3554,7 +3970,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -3586,6 +4001,14 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-store": {
@@ -3665,7 +4088,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -4188,6 +4610,30 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4229,6 +4675,11 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4384,7 +4835,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -4399,7 +4849,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -4805,7 +5254,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4833,7 +5281,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -4882,7 +5329,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4914,11 +5360,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -4933,12 +5388,10 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5069,9 +5522,7 @@
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -5081,9 +5532,7 @@
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5096,15 +5545,11 @@
     },
     "node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -5738,7 +6183,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5859,7 +6303,6 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-exists": {
@@ -5879,7 +6322,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5892,7 +6334,6 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5907,12 +6348,10 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.1.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6244,11 +6683,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -6514,33 +6959,25 @@
     },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
     },
     "node_modules/readdir-glob/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6767,7 +7204,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6782,8 +7218,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6857,7 +7292,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6868,7 +7302,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6992,18 +7425,25 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7017,7 +7457,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7030,7 +7469,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7042,7 +7480,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7230,28 +7667,20 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp-file": {
@@ -7293,6 +7722,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/thenify": {
@@ -7519,7 +7969,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/verror": {
@@ -7876,7 +8325,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7924,7 +8372,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8024,41 +8471,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^3.0.4",
-        "compress-commons": "^4.1.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.2.3",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "packages/slippi-api": {

--- a/supabase/migrations/024_add_app_version.sql
+++ b/supabase/migrations/024_add_app_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS app_version TEXT;

--- a/supabase/migrations/049_mutual_friends.sql
+++ b/supabase/migrations/049_mutual_friends.sql
@@ -1,0 +1,152 @@
+-- Backfill: hide_avatar was added to production outside of migrations.
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS hide_avatar BOOLEAN DEFAULT FALSE;
+
+-- Mutual friends feature: precomputed counts table, trigger maintenance, privacy, and RPCs.
+
+-- A. Precomputed mutual friend counts (canonical pair ordering: user_a < user_b)
+CREATE TABLE mutual_friend_counts (
+  user_a uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  user_b uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  mutual_count integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (user_a, user_b),
+  CHECK (user_a < user_b)
+);
+
+CREATE INDEX idx_mfc_a ON mutual_friend_counts (user_a, mutual_count DESC);
+CREATE INDEX idx_mfc_b ON mutual_friend_counts (user_b, mutual_count DESC);
+
+-- B. Trigger function: maintain mutual_friend_counts on friends INSERT/UPDATE/DELETE
+CREATE OR REPLACE FUNCTION refresh_mutual_counts()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_user uuid;
+  v_friend uuid;
+  v_is_remove boolean := false;
+  r record;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status != 'accepted' OR OLD.friend_id IS NULL THEN RETURN OLD; END IF;
+    v_user := OLD.user_id;
+    v_friend := OLD.friend_id;
+    v_is_remove := true;
+  ELSIF TG_OP = 'INSERT' THEN
+    IF NEW.status != 'accepted' OR NEW.friend_id IS NULL THEN RETURN NEW; END IF;
+    v_user := NEW.user_id;
+    v_friend := NEW.friend_id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF OLD.status != 'accepted' AND NEW.status = 'accepted' AND NEW.friend_id IS NOT NULL THEN
+      v_user := NEW.user_id;
+      v_friend := NEW.friend_id;
+    ELSIF OLD.status = 'accepted' AND OLD.friend_id IS NOT NULL
+      AND (NEW.status != 'accepted' OR NEW.friend_id IS NULL) THEN
+      v_user := OLD.user_id;
+      v_friend := OLD.friend_id;
+      v_is_remove := true;
+    ELSE
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  FOR r IN
+    SELECT user_id AS other_user
+    FROM friends
+    WHERE friend_id = v_friend
+      AND status = 'accepted'
+      AND user_id != v_user
+  LOOP
+    IF v_is_remove THEN
+      UPDATE mutual_friend_counts
+      SET mutual_count = mutual_count - 1
+      WHERE user_a = LEAST(v_user, r.other_user)
+        AND user_b = GREATEST(v_user, r.other_user);
+
+      DELETE FROM mutual_friend_counts
+      WHERE user_a = LEAST(v_user, r.other_user)
+        AND user_b = GREATEST(v_user, r.other_user)
+        AND mutual_count <= 0;
+    ELSE
+      INSERT INTO mutual_friend_counts (user_a, user_b, mutual_count)
+      VALUES (LEAST(v_user, r.other_user), GREATEST(v_user, r.other_user), 1)
+      ON CONFLICT (user_a, user_b)
+      DO UPDATE SET mutual_count = mutual_friend_counts.mutual_count + 1;
+    END IF;
+  END LOOP;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;
+
+CREATE TRIGGER trg_mutual_counts
+  AFTER INSERT OR UPDATE OR DELETE ON friends
+  FOR EACH ROW EXECUTE FUNCTION refresh_mutual_counts();
+
+-- C. Backfill from existing accepted friendships
+INSERT INTO mutual_friend_counts (user_a, user_b, mutual_count)
+SELECT LEAST(a.user_id, b.user_id), GREATEST(a.user_id, b.user_id), COUNT(*)::integer
+FROM friends a
+INNER JOIN friends b
+  ON b.friend_id = a.friend_id
+ AND b.status = 'accepted'
+ AND b.friend_id IS NOT NULL
+ AND b.user_id != a.user_id
+WHERE a.status = 'accepted'
+  AND a.friend_id IS NOT NULL
+  AND a.user_id < b.user_id
+GROUP BY LEAST(a.user_id, b.user_id), GREATEST(a.user_id, b.user_id)
+ON CONFLICT (user_a, user_b) DO UPDATE SET mutual_count = EXCLUDED.mutual_count;
+
+-- D. Privacy column
+ALTER TABLE profiles ADD COLUMN hide_mutual_friends BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- E. Partial index for efficient single-pair detail queries
+CREATE INDEX idx_friends_accepted_friend
+  ON friends (friend_id, user_id)
+  WHERE status = 'accepted' AND friend_id IS NOT NULL;
+
+-- F. RPC: get mutual friend profiles for a single pair (on-demand, bounded by min(F1, F2))
+CREATE OR REPLACE FUNCTION public.get_mutual_friends(p_target_id uuid)
+RETURNS TABLE (
+  id uuid, connect_code text, display_name text, avatar_url text,
+  rating numeric, top_characters jsonb, region text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT p.id, p.connect_code, p.display_name,
+         p.avatar_url,
+         pr.effective_rating, p.top_characters,
+         CASE WHEN p.hide_region THEN NULL ELSE COALESCE(p.chosen_region, p.region) END
+  FROM friends my
+  INNER JOIN friends theirs
+    ON theirs.user_id = p_target_id
+   AND theirs.status = 'accepted'
+   AND theirs.friend_id IS NOT NULL
+   AND theirs.friend_id = my.friend_id
+  INNER JOIN profiles p ON p.id = my.friend_id
+  LEFT JOIN player_ratings pr ON pr.connect_code = p.connect_code
+  WHERE my.user_id = auth.uid()
+    AND my.status = 'accepted'
+    AND my.friend_id IS NOT NULL
+    AND NOT COALESCE(p.hide_mutual_friends, FALSE);
+$$;
+
+REVOKE ALL ON FUNCTION public.get_mutual_friends(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_mutual_friends(uuid) TO authenticated;
+
+-- G. Replace discover_mutual_friend_counts with cache-backed version
+CREATE OR REPLACE FUNCTION public.discover_mutual_friend_counts(p_candidate_ids uuid[])
+RETURNS TABLE (candidate_id uuid, mutual_count integer)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    CASE WHEN mfc.user_a = auth.uid() THEN mfc.user_b ELSE mfc.user_a END,
+    mfc.mutual_count
+  FROM mutual_friend_counts mfc
+  WHERE (mfc.user_a = auth.uid() AND mfc.user_b = ANY(p_candidate_ids))
+     OR (mfc.user_b = auth.uid() AND mfc.user_a = ANY(p_candidate_ids));
+$$;
+
+-- RLS on the cache table: users can read rows they are part of
+ALTER TABLE mutual_friend_counts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mfc_read_own" ON mutual_friend_counts FOR SELECT
+  USING (auth.uid() = user_a OR auth.uid() = user_b);

--- a/supabase/migrations/049_mutual_friends.sql
+++ b/supabase/migrations/049_mutual_friends.sql
@@ -2,6 +2,39 @@
 ALTER TABLE profiles ADD COLUMN IF NOT EXISTS hide_avatar BOOLEAN DEFAULT FALSE;
 
 -- Mutual friends feature: precomputed counts table, trigger maintenance, privacy, and RPCs.
+--
+-- Complexity (let F = friends of affected user, N = total users, C = discover candidates):
+--
+--   refresh_mutual_counts() trigger (per friendship change):
+--     Time:  O(F) -- loops friends of v_friend, each does a PK upsert/delete at O(1).
+--     Space: O(F) for the loop cursor; net table growth is at most F rows.
+--
+--   Backfill query (Section C, runs once at migration time):
+--     Time:  O(E * F_avg) -- self-joins friends on friend_id, index-driven via
+--            idx_friends_accepted_friend. E = accepted edges, F_avg = avg friends/user.
+--     Space: O(P) where P = distinct user pairs sharing a mutual friend (worst case O(N^2)).
+--
+--   discover_mutual_friend_counts RPC (Discover page):
+--     Time:  O(C) where C = |p_candidate_ids| (capped at 50 by caller).
+--            Each candidate lookup is O(log P_user) via idx_mfc_a / idx_mfc_b.
+--     Space: O(C) for the result set.
+--
+--   "Has Mutual Friends" toggle (client-side Discover filter):
+--     Time:  O(C) -- filters already-fetched array to mutualFriendCount > 0. No extra query.
+--     Space: O(C) for the filtered subset.
+--
+--   get_mutual_friends RPC (per-player popover):
+--     Time:  O(min(F_me, F_them)) -- intersects two friend lists via index nested-loop join
+--            on idx_friends_accepted_friend.
+--     Space: O(M) where M = mutual friends returned (intersection size).
+--
+--   mutual_friend_counts table (storage):
+--     Space: O(P) total. Fixed-size rows (two UUIDs + integer). CHECK (user_a < user_b)
+--            prevents duplicates. Two secondary indexes add O(P) each.
+--
+--   Frontend (Discover.tsx):
+--     Time:  O(C log C) for sort + render. hasMutualFriends filter is a linear pass.
+--     Space: O(C) for React state (players array, filtered memo, add-state maps).
 
 -- A. Precomputed mutual friend counts (canonical pair ordering: user_a < user_b)
 CREATE TABLE mutual_friend_counts (


### PR DESCRIPTION
### Find people in your friendlies circles!

Displays mutual friends count in Discover and allows you to filter by players who are friends of your friends. Includes privacy toggle for filtering yourself out. 

|<img alt="image" src="https://github.com/user-attachments/assets/22118c60-b6fe-41c2-9705-795f8f0fd035" />| <img alt="image" src="https://github.com/user-attachments/assets/b964cd21-a2b5-45eb-a5ca-bf4d0f3b8932" />|
|---|---|
|<img  alt="image" src="https://github.com/user-attachments/assets/e2545b79-daea-4079-b557-20be675d2147" />| 
   
 


**Time / Space complexity:**
Precomputes mutual friend counts via a Postgres trigger that fires on each friendship change, costing **O(*F*)** per write where *F* is the shared friend's friend count. The Discover page's existing endpoint calls the `discover_mutual_friend_counts` RPC to attach counts to each candidate, hitting the precomputed `mutual_friend_counts` table with a hard cap of 50 candidates, making the lookup effectively **O(1)** per candidate via index. The `get_mutual_friends` detail RPC, used by the per-player popover, is **O(min(*F_me*, *F_them*))** since it intersects two friend lists via an index join. Total storage is **O(*P*)** where *P* is the number of user pairs sharing at least one friend, with one compact row per pair.

More details available as comments in migration file `049_mutual_friends.sql`

Also includes changes from [my previous PR](https://github.com/0xburn/friendlies/pull/10).


Resolves #11 


