### PR TITLE
Fix duplicate migration error

### DIFF
--- a/supabase/migrations/002_add_app_version.sql
+++ b/supabase/migrations/002_add_app_version.sql
@@ -1,1 +1,0 @@
-ALTER TABLE profiles ADD COLUMN IF NOT EXISTS app_version TEXT;

--- a/supabase/migrations/002_dedup_and_friends_offline.sql
+++ b/supabase/migrations/002_dedup_and_friends_offline.sql
@@ -1,3 +1,6 @@
+-- The following command only is originally from 002_add_app_version.sql
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS app_version TEXT;
+
 -- 1. Deduplicate matches by replay_filename per user
 DELETE FROM matches a USING matches b
   WHERE a.id > b.id


### PR DESCRIPTION
In trying to run the Supabase setup locally, I ran into an issue because the prefix `002_` had already been used by the time it went to execute `002_dedup_and_friends_offline.sql`. This PR fixes this by combining the two `002` migrations into one.

I assume this will not break anyone's local setup, since if such a check for changes or issues was being run, I would imagine this bug would have been caught earlier.

---

Also some feedback from local development if it's useful:
- It doesn't appear that a `.env` file in the same directory as `.env.example` is automatically loaded  on `npm run dev:agent` or `npm run dev:web`
- I think I figured out how to point my local at Supabase, but I could not figure out how to log in after that. I have been doing local development by logging in through the production app, and then `npm run dev:agent` is logged in for me. With the local Supabase, this doesn't work - some guides on local development for things like this, or utilities, would be very useful