### PR TITLE
Add business logic to broadcast to SpectatorMode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # start.gg OAuth — Edge Function secrets (set via `supabase secrets set`, NEVER in .env)
 # STARTGG_CLIENT_ID=your-startgg-oauth-client-id
 # STARTGG_CLIENT_SECRET=your-startgg-oauth-client-secret
+
+# For streaming to SpectatorMode
+# STREAM_WS_DEST=ws://localhost:4000/bridge_socket/websocket

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -25,6 +25,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.26.0",
+    "slippi-web-bridge": "^0.5.1",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/apps/agent/src/ipc.ts
+++ b/apps/agent/src/ipc.ts
@@ -11,6 +11,7 @@ import { resolvePresenceRow } from './presence-logic';
 import { getConnectionType, getLfgCharacters, getLfgExpiry, getLfgRanks, getLocalStatusSnapshot, getOnlineUsers, getPresenceStats, getStatusPreset, isLookingToPlay, onLocalStatusChange, onPresenceSync, setGameThrottling, setHideConnectionType, setHideOnlineStatus, setLfgCharacters, setLfgExpiry, setLfgRanks, setRendererDocumentHidden, setStatusPreset, toggleLookingToPlay } from './presence';
 import { showTestNotification } from './notifications';
 import { getSettings, isSetupComplete, updateSettings, type AgentSettings } from './settings';
+import { startStream, stopStream } from './stream';
 import { updateTrayStatus } from './tray';
 import { supabase } from './supabase';
 import { checkForUpdates, downloadUpdate, quitAndInstall } from './updater';
@@ -2218,5 +2219,20 @@ export function registerIpcHandlers(
       connected: isStartGgConnected(),
       ...getStartGgUserInfo(),
     };
+  });
+
+  // --- Streaming ---
+
+  ipcMain.handle('stream:start', async () => {
+    try {
+      return { streamId: await startStream() };
+    } catch (e: any) {
+      return { error: e.message };
+    }
+  });
+
+  ipcMain.handle('stream:stop', () => {
+    stopStream();
+    return { ok: true };
   });
 }

--- a/apps/agent/src/preload.ts
+++ b/apps/agent/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { DisconnectReason } from 'slippi-web-bridge';
 
 type Unsubscribe = () => void;
 
@@ -208,6 +209,10 @@ const api = {
   testNotification: () => ipcRenderer.invoke('notifications:test'),
   reportDocumentHidden: (hidden: boolean) => ipcRenderer.send('visibility:document', hidden),
   onGameActive: (cb: (active: boolean) => void): Unsubscribe => onEvent('game:active', cb),
+
+  startStream: () => ipcRenderer.invoke('stream:start'),
+  stopStream: () => ipcRenderer.invoke('stream:stop'),
+  onStreamDisconnected: (cb: (reason: DisconnectReason) => void): Unsubscribe => onEvent('stream:disconnected', cb),
 };
 
 export type ElectronAPI = typeof api;

--- a/apps/agent/src/stream.ts
+++ b/apps/agent/src/stream.ts
@@ -1,0 +1,37 @@
+import { sendToRenderer } from './ipc';
+import { Bridge } from 'slippi-web-bridge';
+
+let bridge: Bridge | null = null;
+
+const STREAM_WS_DEST_FALLBACK = 'wss://spectatormode.tv/bridge_socket/websocket';
+const streamWsDest = process.env.STREAM_WS_DEST ?? STREAM_WS_DEST_FALLBACK;
+
+function getOrCreateBridge(): Bridge {
+  if (!bridge) {
+    bridge = new Bridge();
+
+    bridge.onDisconnect(reason => {
+      sendToRenderer('stream:disconnected', reason);
+    });
+  }
+
+  return bridge;
+}
+
+export async function startStream(): Promise<number> {
+  const bridge = getOrCreateBridge();
+  const { data, error } = await bridge.connect(streamWsDest);
+
+  if (error) {
+    throw new Error(error);
+  }
+
+  const streamId = data!.streamIds[0];
+  return streamId;
+}
+
+export function stopStream() {
+  if (bridge) {
+    bridge.quit();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.26.0",
+        "slippi-web-bridge": "^0.5.1",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -6915,6 +6916,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slippi-web-bridge": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/slippi-web-bridge/-/slippi-web-bridge-0.5.1.tgz",
+      "integrity": "sha512-McsMWi/EGOExmX/sU/+XiF60NwuRKIa1S1VJhsRKELwavoPzQr3zpLqnUp2DD5bLLH3maYQ2nint+R/z6m7JXg==",
+      "license": "ISC",
+      "dependencies": {
+        "@slippi/slippi-js": "^9.0.0",
+        "ws": "^8.18.1"
       }
     },
     "node_modules/smart-buffer": {


### PR DESCRIPTION
Hello, I wanted to gauge interest on the addition of easy, lightweight streaming directly via Slippi.

A while back I created [SpectatorMode](https://spectatormode.tv), which enables exactly this. My biggest issue was always that it requires running an additional program next to Slippi, which is hard to get people to do. So, when I saw Friendlies (awesome work btw), this immediately seemed like a great opportunity. The end vision would be to both easily and non-intrusively allow people to stream from Friendlies (which this PR sets the stage for), and watch/preview their friends' streams directly in the application (which will be possible via a [viewer component I've extracted from SlippiLab](https://github.com/gcpreston/slippi-viewer)).

This is an initial PR to add some main process logic which allows a stream to be started and stopped. It's pretty simple, though I left out two things:
1. Presence logic. I figure you want to see whether your friends are streaming in-app, but I was having trouble getting Supabase working locally, so for now [I have a separate branch for that](https://github.com/gcpreston/friendlies/tree/broadcast-to-spectatormode-with-presence).
2. Frontend. I figure this is something the owner of the application would want to handle, but in the meantime I made [a proof of concept branch](https://github.com/gcpreston/friendlies/tree/broadcast-to-spectatormode-with-frontend-poc) to demonstrate the API introduced in this PR.

Demo with the frontend changes: https://youtu.be/nnmFKmcQBxY

Let me know if you have any thoughts, including for the other branches, and feel free to edit anything :)